### PR TITLE
Patch/refresh token

### DIFF
--- a/lib/features/beat_plan/views/beat_plan_details_screen.dart
+++ b/lib/features/beat_plan/views/beat_plan_details_screen.dart
@@ -45,6 +45,7 @@ class _BeatPlanDetailsScreenState extends ConsumerState<BeatPlanDetailsScreen> {
 
   /// Get current location for geofencing
   Future<void> _getCurrentLocation() async {
+    if (!mounted) return;
     setState(() => _isLoadingLocation = true);
     try {
       // Check location permission
@@ -86,6 +87,7 @@ class _BeatPlanDetailsScreenState extends ConsumerState<BeatPlanDetailsScreen> {
         ),
       );
 
+      if (!mounted) return;
       setState(() {
         _currentLocation = position;
       });
@@ -102,7 +104,9 @@ class _BeatPlanDetailsScreenState extends ConsumerState<BeatPlanDetailsScreen> {
         );
       }
     } finally {
-      setState(() => _isLoadingLocation = false);
+      if (mounted) {
+        setState(() => _isLoadingLocation = false);
+      }
     }
   }
 

--- a/lib/features/beat_plan/widgets/beat_plan_section.dart
+++ b/lib/features/beat_plan/widgets/beat_plan_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sales_sphere/core/constants/app_colors.dart';
 import 'package:sales_sphere/core/utils/logger.dart';
+import 'package:sales_sphere/core/utils/snackbar_utils.dart';
 import 'package:sales_sphere/core/services/location_permission_service.dart';
 import 'package:sales_sphere/core/widgets/location_permission_dialog.dart';
 import 'package:sales_sphere/features/beat_plan/vm/beat_plan.vm.dart';
@@ -114,12 +115,9 @@ class _BeatPlanSectionState extends ConsumerState<BeatPlanSection> {
 
         if (requestedAgain != true) {
           // User cancelled or denied
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Location permission is required for tracking'),
-              backgroundColor: AppColors.warning,
-              duration: Duration(seconds: 3),
-            ),
+          SnackbarUtils.showWarning(
+            context,
+            'Location permission is required for tracking',
           );
           return;
         }
@@ -132,12 +130,9 @@ class _BeatPlanSectionState extends ConsumerState<BeatPlanSection> {
         );
 
         if (!retryResult.success) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Location permission is required for tracking'),
-              backgroundColor: AppColors.error,
-              duration: Duration(seconds: 3),
-            ),
+          SnackbarUtils.showError(
+            context,
+            'Location permission is required for tracking',
           );
           return;
         }
@@ -158,12 +153,9 @@ class _BeatPlanSectionState extends ConsumerState<BeatPlanSection> {
 
       if (success && mounted) {
         // Show success message
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: const Text('Beat plan started successfully! Tracking is now active.'),
-            backgroundColor: AppColors.success,
-            duration: const Duration(seconds: 3),
-          ),
+        SnackbarUtils.showSuccess(
+          context,
+          'Beat plan started successfully! Tracking is now active.',
         );
 
         // Navigate to beat plan details
@@ -175,12 +167,9 @@ class _BeatPlanSectionState extends ConsumerState<BeatPlanSection> {
     } catch (e) {
       AppLogger.e('Error starting beat plan: $e');
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Failed to start beat plan: ${e.toString()}'),
-            backgroundColor: AppColors.error,
-            duration: const Duration(seconds: 3),
-          ),
+        SnackbarUtils.showError(
+          context,
+          'Failed to start beat plan: ${e.toString()}',
         );
       }
     } finally {

--- a/lib/features/beat_plan/widgets/beat_plan_summary_card.dart
+++ b/lib/features/beat_plan/widgets/beat_plan_summary_card.dart
@@ -142,7 +142,7 @@ class _BeatPlanSummaryCardState extends State<BeatPlanSummaryCard> {
                 ),
 
                 // Started time if available
-                if (status == 'in-progress' && widget.beatPlan.startedAt != null) ...[
+                if ((status == 'in-progress' || status == 'active') && widget.beatPlan.startedAt != null) ...[
                   SizedBox(height: 6.h),
                   Row(
                     children: [
@@ -397,9 +397,9 @@ class _BeatPlanSummaryCardState extends State<BeatPlanSummaryCard> {
 
   Color _getProgressColor(String status, int percentage) {
     if (status == 'completed' || percentage == 100) return AppColors.success;
-    if (status == 'in-progress') return AppColors.secondary;
+    if (status == 'in-progress' || status == 'active') return AppColors.secondary;
     // For pending (0%), the widthFactor will be 0, so color doesn't matter
-    return AppColors.secondary;
+    return AppColors.greyLight;
   }
 
   String _formatDate(String dateStr) {


### PR DESCRIPTION
This pull request introduces several improvements and fixes across authentication handling, user experience for location permissions, and beat plan UI logic. The most significant changes enhance the robustness of token refresh logic, standardize snackbar notifications, and improve UI feedback for beat plan statuses.

**Authentication and Token Refresh Improvements:**

* Prevents infinite token refresh loops by detecting if a 401 error occurred during a refresh attempt and clearing auth data instead of retrying.
* Removes premature session expiry checks on the client, deferring all session validity decisions to the backend for greater reliability. [[1]](diffhunk://#diff-613143c27a1efe40b54e63670557003042af24c864e2c645b1d3b7ab14188fedR148) [[2]](diffhunk://#diff-613143c27a1efe40b54e63670557003042af24c864e2c645b1d3b7ab14188fedL148-R159)
* Improves refresh token response handling by checking for tokens at the root level first (for mobile clients), then nested data, and adds detailed logging for both success and failure scenarios. [[1]](diffhunk://#diff-613143c27a1efe40b54e63670557003042af24c864e2c645b1d3b7ab14188fedL193-R203) [[2]](diffhunk://#diff-613143c27a1efe40b54e63670557003042af24c864e2c645b1d3b7ab14188fedL204-R251)
* Adds the `X-Client-Type: mobile` header to refresh requests to support backend differentiation for mobile clients.

**Location Permission and Snackbar UX Enhancements:**

* Replaces direct `ScaffoldMessenger` snackbars with `SnackbarUtils` for consistent, centralized user notifications regarding location permissions and beat plan actions. [[1]](diffhunk://#diff-2a80b96b7b30ea6d906e87e168448d98ead8981c25b970a7480bfa297705a0e1R7) [[2]](diffhunk://#diff-2a80b96b7b30ea6d906e87e168448d98ead8981c25b970a7480bfa297705a0e1L117-R120) [[3]](diffhunk://#diff-2a80b96b7b30ea6d906e87e168448d98ead8981c25b970a7480bfa297705a0e1L135-R135) [[4]](diffhunk://#diff-2a80b96b7b30ea6d906e87e168448d98ead8981c25b970a7480bfa297705a0e1L161-R158) [[5]](diffhunk://#diff-2a80b96b7b30ea6d906e87e168448d98ead8981c25b970a7480bfa297705a0e1L178-R172)
* Ensures `setState` is only called when the widget is mounted in location-related async operations, preventing potential runtime errors. [[1]](diffhunk://#diff-7a401cc42cdb1484327b764aca927ecb1876498bb82aa8404b1a6be54eddb3e8R48) [[2]](diffhunk://#diff-7a401cc42cdb1484327b764aca927ecb1876498bb82aa8404b1a6be54eddb3e8R90) [[3]](diffhunk://#diff-7a401cc42cdb1484327b764aca927ecb1876498bb82aa8404b1a6be54eddb3e8R107-R111)

**Beat Plan UI Logic Adjustments:**

* Updates beat plan summary card logic to display the started time and use the correct color for both `'in-progress'` and `'active'` statuses, ensuring accurate visual feedback. [[1]](diffhunk://#diff-ebfe8445a40796f73ef2826731200c72aee96df54b0bb33e741b518b6dad729aL145-R145) [[2]](diffhunk://#diff-ebfe8445a40796f73ef2826731200c72aee96df54b0bb33e741b518b6dad729aL400-R402)