### PR TITLE
UI: Implemented the screen of tour_plan, add_tour and edit_plan

### DIFF
--- a/lib/core/router/route_handler.dart
+++ b/lib/core/router/route_handler.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:sales_sphere/features/tour_plan/views/add_tour_screen.dart';
+import 'package:sales_sphere/features/tour_plan/views/edit_tour_details_screen.dart';
+import 'package:sales_sphere/features/tour_plan/views/tour_plan_screen.dart';
 import 'package:sales_sphere/widget/main_shell.dart';
 import 'package:sales_sphere/features/auth/views/login_screen.dart';
 import 'package:sales_sphere/features/auth/views/forgot_password_screen.dart';
@@ -106,6 +109,9 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           requestedPath.startsWith('/miscellaneous-work');
       final isGoingToExpenseClaims =
           requestedPath.startsWith('/expense-claims');
+      final isGoingToTourPlans = requestedPath == '/tour-plans';
+      final isGoingToAddTour = requestedPath == '/add-tour';
+      final isGoingToEditTour = requestedPath.startsWith('/edit-tour');
 
       // If user is not logged in AND not going to one of the allowed pages...
       if (!isLoggedIn &&
@@ -129,7 +135,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           !isGoingToUtilities &&
           !isGoingToSettings &&
           !isGoingToMiscellaneous &&
-          !isGoingToExpenseClaims) {
+          !isGoingToExpenseClaims &&
+          !isGoingToTourPlans &&
+          !isGoingToAddTour &&
+          !isGoingToEditTour) {
         return '/';
       }
 
@@ -328,6 +337,28 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             siteName = extras['siteName'] as String? ?? 'Site';
           }
           return SitesImagesScreen(siteId: siteId, siteName: siteName);
+        },
+      ),
+
+      // ========================================
+      // TOUR PLAN ROUTES
+      // ========================================
+      GoRoute(
+        path: '/tour-plans',
+        name: 'tour-plans',
+        builder: (context, state) => const TourPlanScreen(),
+      ),
+      GoRoute(
+        path: '/add-tour',
+        name: 'add-tour',
+        builder: (context, state) => const AddTourPlanScreen(),
+      ),
+      GoRoute(
+        path: '/edit-tour/:tourId',
+        name: 'edit-tour',
+        builder: (context, state) {
+          final tourId = state.pathParameters['tourId'] ?? '';
+          return EditTourDetailsScreen(tourId: tourId);
         },
       ),
 

--- a/lib/features/tour_plan/models/add_tour.models.dart
+++ b/lib/features/tour_plan/models/add_tour.models.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'add_tour.models.freezed.dart';
+part 'add_tour.models.g.dart';
+
+@freezed
+abstract class CreateTourRequest with _$CreateTourRequest {
+  const factory CreateTourRequest({
+    required String placeOfVisit,
+    required String startDate,
+    required String endDate,
+    required String purposeOfVisit,
+  }) = _CreateTourRequest;
+
+  factory CreateTourRequest.fromJson(Map<String, dynamic> json) =>
+      _$CreateTourRequestFromJson(json);
+}
+
+@freezed
+abstract class TourListItem with _$TourListItem {
+  const factory TourListItem({
+    required String id,
+    required String placeOfVisit,
+    required String startDate,
+    required String endDate,
+    required String purposeOfVisit,
+  }) = _TourListItem;
+
+  factory TourListItem.fromJson(Map<String, dynamic> json) =>
+      _$TourListItemFromJson(json);
+}

--- a/lib/features/tour_plan/models/edit_tour.model.dart
+++ b/lib/features/tour_plan/models/edit_tour.model.dart
@@ -1,0 +1,55 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'edit_tour.model.freezed.dart';
+part 'edit_tour.model.g.dart';
+
+@freezed
+abstract class TourDetails with _$TourDetails {
+  const TourDetails._();
+
+  const factory TourDetails({
+    required String id,
+    required String placeOfVisit,
+    required String startDate,
+    required String endDate,
+    required String purposeOfVisit,
+    @Default('Pending') String status, // For the "Tour Plan Status" banner
+    String? createdAt,
+    String? updatedAt,
+  }) = _TourDetails;
+
+  factory TourDetails.fromJson(Map<String, dynamic> json) => _$TourDetailsFromJson(json);
+
+  // Helper to convert from a general API response if needed
+  factory TourDetails.fromApi(Map<String, dynamic> json) {
+    return TourDetails(
+      id: json['_id'] ?? '',
+      placeOfVisit: json['placeOfVisit'] ?? '',
+      startDate: json['startDate'] ?? '',
+      endDate: json['endDate'] ?? '',
+      purposeOfVisit: json['purposeOfVisit'] ?? '',
+      status: json['status'] ?? 'Pending',
+    );
+  }
+}
+
+@freezed
+abstract class UpdateTourRequest with _$UpdateTourRequest {
+  const factory UpdateTourRequest({
+    required String placeOfVisit,
+    required String startDate,
+    required String endDate,
+    required String purposeOfVisit,
+  }) = _UpdateTourRequest;
+
+  factory UpdateTourRequest.fromJson(Map<String, dynamic> json) => _$UpdateTourRequestFromJson(json);
+
+  factory UpdateTourRequest.fromDetails(TourDetails details) {
+    return UpdateTourRequest(
+      placeOfVisit: details.placeOfVisit,
+      startDate: details.startDate,
+      endDate: details.endDate,
+      purposeOfVisit: details.purposeOfVisit,
+    );
+  }
+}

--- a/lib/features/tour_plan/models/tour_plan.model.dart
+++ b/lib/features/tour_plan/models/tour_plan.model.dart
@@ -1,0 +1,70 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'tour_plan.model.freezed.dart';
+part 'tour_plan.model.g.dart';
+
+// ============================================================================
+// API Response Models
+// ============================================================================
+
+@freezed
+abstract class TourPlanApiResponse with _$TourPlanApiResponse {
+  const factory TourPlanApiResponse({
+    required bool success,
+    required int count,
+    required List<TourPlanApiData> data,
+  }) = _TourPlanApiResponse;
+
+  factory TourPlanApiResponse.fromJson(Map<String, dynamic> json) =>
+      _$TourPlanApiResponseFromJson(json);
+}
+
+@freezed
+abstract class TourPlanApiData with _$TourPlanApiData {
+  const factory TourPlanApiData({
+    @JsonKey(name: '_id') required String id,
+    required String placeOfVisit,
+    required String startDate,
+    required String endDate,
+    required String purposeOfVisit,
+    required String status,
+    String? createdAt,
+  }) = _TourPlanApiData;
+
+  factory TourPlanApiData.fromJson(Map<String, dynamic> json) =>
+      _$TourPlanApiDataFromJson(json);
+}
+
+// ============================================================================
+// App Models
+// ============================================================================
+
+@freezed
+abstract class TourPlanListItem with _$TourPlanListItem {
+  const factory TourPlanListItem({
+    required String id,
+    required String placeOfVisit,
+    required String startDate,
+    required String endDate,
+    required String status,
+    required int durationDays,
+  }) = _TourPlanListItem;
+
+  /// Converts API data and calculates duration inclusive of both start and end dates.
+  factory TourPlanListItem.fromApiData(TourPlanApiData apiData) {
+    final start = DateTime.tryParse(apiData.startDate) ?? DateTime.now();
+    final end = DateTime.tryParse(apiData.endDate) ?? DateTime.now();
+
+    // Difference in days + 1 to include the end date as a working day
+    final duration = end.difference(start).inDays + 1;
+
+    return TourPlanListItem(
+      id: apiData.id,
+      placeOfVisit: apiData.placeOfVisit,
+      startDate: apiData.startDate,
+      endDate: apiData.endDate,
+      status: apiData.status,
+      durationDays: duration,
+    );
+  }
+}

--- a/lib/features/tour_plan/views/add_tour_screen.dart
+++ b/lib/features/tour_plan/views/add_tour_screen.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sales_sphere/core/constants/app_colors.dart';
+import 'package:sales_sphere/widget/custom_text_field.dart';
+import 'package:sales_sphere/widget/custom_button.dart';
+import 'package:sales_sphere/widget/custom_date_picker.dart';
+import '../models/add_tour.models.dart';
+import '../vm/add_tour.vm.dart';
+
+class AddTourPlanScreen extends ConsumerStatefulWidget {
+  const AddTourPlanScreen({super.key});
+
+  @override
+  ConsumerState<AddTourPlanScreen> createState() => _AddTourPlanScreenState();
+}
+
+class _AddTourPlanScreenState extends ConsumerState<AddTourPlanScreen> {
+  final _formKey = GlobalKey<FormState>();
+
+  final _placeController = TextEditingController();
+  final _startDateController = TextEditingController();
+  final _endDateController = TextEditingController();
+  final _purposeController = TextEditingController();
+
+  @override
+  void dispose() {
+    _placeController.dispose();
+    _startDateController.dispose();
+    _endDateController.dispose();
+    _purposeController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSave() async {
+    if (_formKey.currentState?.validate() ?? false) {
+      final request = CreateTourRequest(
+        placeOfVisit: _placeController.text.trim(),
+        startDate: _startDateController.text.trim(),
+        endDate: _endDateController.text.trim(),
+        purposeOfVisit: _purposeController.text.trim(),
+      );
+
+      final success = await ref
+          .read(addTourViewModelProvider.notifier)
+          .saveTourPlanLocally(request);
+
+      if (success && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Tour Plan saved locally (Frontend only)'),
+            backgroundColor: AppColors.success,
+          ),
+        );
+        context.pop();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF2C435D), // Match the dark blue in your image
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        centerTitle: true,
+        title: Text(
+          "Add Tour Plan",
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 20.sp,
+            fontWeight: FontWeight.w600,
+            fontFamily: 'Poppins',
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: Column(
+        children: [
+          SizedBox(height: 20.h),
+          Expanded(
+            child: Container(
+              width: double.infinity,
+              padding: EdgeInsets.fromLTRB(24.w, 32.h, 24.w, 24.h),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(32.r),
+                  topRight: Radius.circular(32.r),
+                ),
+              ),
+              child: Form(
+                key: _formKey,
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      PrimaryTextField(
+                        hintText: "Place of visit",
+                        controller: _placeController,
+                        prefixIcon: Icons.location_on_outlined,
+                        validator: (v) => ref
+                            .read(addTourViewModelProvider.notifier)
+                            .validateRequired(v, "Place"),
+                      ),
+                      SizedBox(height: 16.h),
+                      CustomDatePicker(
+                        hintText: "Start Date",
+                        controller: _startDateController,
+                        prefixIcon: Icons.calendar_today_outlined,
+                      ),
+                      SizedBox(height: 16.h),
+                      CustomDatePicker(
+                        hintText: "End Date",
+                        controller: _endDateController,
+                        prefixIcon: Icons.calendar_today_outlined,
+                      ),
+                      SizedBox(height: 16.h),
+                      PrimaryTextField(
+                        hintText: "Purpose of the visit",
+                        controller: _purposeController,
+                        prefixIcon: Icons.description_outlined,
+                        hasFocusBorder: true,
+                        minLines: 1,
+                        maxLines: 5,
+                        textInputAction: TextInputAction.newline, 
+                      ),
+                      SizedBox(height: 60.h),
+                      PrimaryButton(
+                        label: 'Add Tour Plan',
+                        onPressed: _handleSave,
+                        width: double.infinity,
+                        size: ButtonSize.medium,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/tour_plan/views/edit_tour_details_screen.dart
+++ b/lib/features/tour_plan/views/edit_tour_details_screen.dart
@@ -1,0 +1,340 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sales_sphere/core/constants/app_colors.dart';
+import 'package:sales_sphere/widget/custom_text_field.dart';
+import 'package:sales_sphere/widget/custom_button.dart';
+import 'package:sales_sphere/widget/custom_date_picker.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import '../models/edit_tour.model.dart';
+import '../vm/edit_tour.vm.dart';
+
+class EditTourDetailsScreen extends ConsumerStatefulWidget {
+  final String tourId;
+
+  const EditTourDetailsScreen({
+    super.key,
+    required this.tourId,
+  });
+
+  @override
+  ConsumerState<EditTourDetailsScreen> createState() => _EditTourDetailsScreenState();
+}
+
+class _EditTourDetailsScreenState extends ConsumerState<EditTourDetailsScreen> {
+  final _formKey = GlobalKey<FormState>();
+  bool _isEditMode = false;
+  bool _isDataLoaded = false;
+
+  // Controllers
+  late TextEditingController _placeController;
+  late TextEditingController _startDateController;
+  late TextEditingController _endDateController;
+  late TextEditingController _purposeController;
+
+  TourDetails? _currentTour;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeControllers();
+  }
+
+  void _initializeControllers() {
+    _placeController = TextEditingController();
+    _startDateController = TextEditingController();
+    _endDateController = TextEditingController();
+    _purposeController = TextEditingController();
+  }
+
+  void _populateFields(TourDetails tour) {
+    _currentTour = tour;
+    _placeController.text = tour.placeOfVisit;
+    _startDateController.text = tour.startDate;
+    _endDateController.text = tour.endDate;
+    _purposeController.text = tour.purposeOfVisit;
+  }
+
+  @override
+  void dispose() {
+    _placeController.dispose();
+    _startDateController.dispose();
+    _endDateController.dispose();
+    _purposeController.dispose();
+    super.dispose();
+  }
+
+  void _toggleEditMode() {
+    setState(() {
+      _isEditMode = !_isEditMode;
+    });
+  }
+
+  Future<void> _handleSave() async {
+    if (_formKey.currentState?.validate() ?? false) {
+      try {
+        final updated = _currentTour!.copyWith(
+          placeOfVisit: _placeController.text.trim(),
+          startDate: _startDateController.text.trim(),
+          endDate: _endDateController.text.trim(),
+          purposeOfVisit: _purposeController.text.trim(),
+        );
+
+        await ref.read(editTourViewModelProvider.notifier).updateTour(updated);
+
+        setState(() => _isEditMode = false);
+
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Tour plan updated successfully'),
+              backgroundColor: AppColors.success,
+            ),
+          );
+        }
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(e.toString()), backgroundColor: AppColors.error),
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tourAsync = ref.watch(tourByIdProvider(widget.tourId));
+
+    // Listen for data to populate fields once
+    ref.listen(tourByIdProvider(widget.tourId), (prev, next) {
+      if (next is AsyncData<TourDetails?> && next.value != null && !_isDataLoaded) {
+        _populateFields(next.value!);
+        _isDataLoaded = true;
+      }
+    });
+
+    return Scaffold(
+      extendBodyBehindAppBar: true,
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        centerTitle: false,
+        titleSpacing: 0,
+        title: Text(
+          "Details",
+          style: TextStyle(
+            color: AppColors.textdark,
+            fontSize: 18.sp,
+            fontWeight: FontWeight.w600,
+            fontFamily: 'Poppins',
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: AppColors.textdark),
+          onPressed: () => context.pop(),
+        ),
+        actions: [
+          if (_isEditMode)
+            TextButton(
+              onPressed: () {
+                setState(() {
+                  _isEditMode = false;
+                  if (_currentTour != null) _populateFields(_currentTour!);
+                });
+              },
+              child: Text(
+                'Cancel',
+                style: TextStyle(
+                  color: AppColors.error,
+                  fontSize: 14.sp,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: SvgPicture.asset(
+              'assets/images/corner_bubble.svg',
+              fit: BoxFit.cover,
+              height: 180.h,
+            ),
+          ),
+          tourAsync.when(
+            data: (tour) => tour == null
+                ? const Center(child: Text("Tour not found"))
+                : _buildContent(tour),
+            loading: () => Skeletonizer(enabled: true, child: _buildContent(null)),
+            error: (e, _) => Center(child: Text(e.toString())),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(TourDetails? tour) {
+    final bool isPending = (tour?.status.toLowerCase() ?? 'pending') == 'pending';
+    final bool isEditable = _isEditMode && isPending;
+
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: EdgeInsets.symmetric(horizontal: 16.w),
+            child: Padding(
+              padding: EdgeInsets.only(top: 100.h, bottom: 16.h),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    // Status Card matching Expenses UI
+                    if (tour != null) _buildStatusCard(tour.status),
+                    SizedBox(height: 24.h),
+
+                    Container(
+                      width: double.infinity,
+                      padding: EdgeInsets.all(16.w),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(16.r),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withOpacity(0.04),
+                            blurRadius: 10,
+                            offset: const Offset(0, 2),
+                          ),
+                        ],
+                      ),
+                      child: Column(
+                        children: [
+                          PrimaryTextField(
+                            hintText: "Place of visit",
+                            controller: _placeController,
+                            prefixIcon: Icons.location_on_outlined,
+                            enabled: isEditable,
+                            hasFocusBorder: true,
+                          ),
+                          SizedBox(height: 16.h),
+                          CustomDatePicker(
+                            hintText: "Start Date",
+                            controller: _startDateController,
+                            prefixIcon: Icons.calendar_today_outlined,
+                            enabled: isEditable,
+                          ),
+                          SizedBox(height: 16.h),
+                          CustomDatePicker(
+                            hintText: "End Date",
+                            controller: _endDateController,
+                            prefixIcon: Icons.calendar_today_outlined,
+                            enabled: isEditable,
+                          ),
+                          SizedBox(height: 16.h),
+                          PrimaryTextField(
+                            hintText: "Purpose of the visit",
+                            controller: _purposeController,
+                            prefixIcon: Icons.description_outlined,
+                            enabled: isEditable,
+                            minLines: 1,
+                            maxLines: 5,
+                            hasFocusBorder: true,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        // Bottom Action Bar
+        if (isPending)
+          Container(
+            padding: EdgeInsets.fromLTRB(16.w, 16.h, 16.w, MediaQuery.of(context).padding.bottom + 16.h),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.06),
+                  blurRadius: 10,
+                  offset: const Offset(0, -2),
+                ),
+              ],
+            ),
+            child: PrimaryButton(
+              label: _isEditMode ? 'Save Changes' : 'Edit Detail',
+              onPressed: _isEditMode ? _handleSave : _toggleEditMode,
+              leadingIcon: _isEditMode ? Icons.check_rounded : Icons.edit_outlined,
+              size: ButtonSize.medium,
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildStatusCard(String status) {
+    Color textColor = const Color(0xFFB78628); // Default Pending Gold
+    Color bgColor = const Color(0xFFFFF9E6);
+    Color borderColor = const Color(0xFFFFECB3);
+
+    if (status.toLowerCase() == 'approved') {
+      textColor = const Color(0xFF2E7D32);
+      bgColor = const Color(0xFFE8F5E9);
+      borderColor = const Color(0xFFC8E6C9);
+    } else if (status.toLowerCase() == 'rejected') {
+      textColor = const Color(0xFFC62828);
+      bgColor = const Color(0xFFFFEBEE);
+      borderColor = const Color(0xFFFFCDD2);
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 16.h),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(20.r),
+        border: Border.all(color: borderColor),
+      ),
+      child: Row(
+        children: [
+          Container(
+            height: 10.w,
+            width: 10.w,
+            decoration: BoxDecoration(color: textColor, shape: BoxShape.circle),
+          ),
+          SizedBox(width: 16.w),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  "Tour Plan Status",
+                  style: TextStyle(fontSize: 11.sp, color: Colors.grey.shade600, fontWeight: FontWeight.w500),
+                ),
+                Text(
+                  status,
+                  style: TextStyle(fontSize: 16.sp, color: textColor, fontWeight: FontWeight.w600),
+                ),
+              ],
+            ),
+          ),
+          if (status.toLowerCase() != 'pending')
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 10.w, vertical: 4.h),
+              decoration: BoxDecoration(color: Colors.white.withOpacity(0.5), borderRadius: BorderRadius.circular(8.r)),
+              child: Text("Read Only", style: TextStyle(fontSize: 10.sp, color: textColor.withOpacity(0.7))),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/tour_plan/views/tour_plan_screen.dart
+++ b/lib/features/tour_plan/views/tour_plan_screen.dart
@@ -1,0 +1,441 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:sales_sphere/features/tour_plan/models/tour_plan.model.dart';
+import 'package:sales_sphere/features/tour_plan/vm/tour_plan.vm.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+import 'package:sales_sphere/core/constants/app_colors.dart';
+
+enum TourFilter { all, pending, approved, rejected }
+
+class TourPlanScreen extends ConsumerStatefulWidget {
+  const TourPlanScreen({super.key});
+
+  @override
+  ConsumerState<TourPlanScreen> createState() => _TourPlanScreenState();
+}
+
+class _TourPlanScreenState extends ConsumerState<TourPlanScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  TourFilter _activeFilter = TourFilter.all;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  String _formatDateRange(String start, String end) {
+    try {
+      final startDate = DateTime.parse(start);
+      final endDate = DateTime.parse(end);
+      final formatter = DateFormat('MMM dd, yyyy');
+      return '${formatter.format(startDate)} - ${formatter.format(endDate)}';
+    } catch (e) {
+      return '$start - $end';
+    }
+  }
+
+  Color _getStatusColor(String status) {
+    switch (status.toLowerCase()) {
+      case 'approved':
+        return Colors.green;
+      case 'pending':
+        return Colors.orange;
+      case 'rejected':
+        return Colors.red;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tourPlansAsync = ref.watch(filteredTourPlansProvider);
+    final searchQuery = ref.watch(tourSearchQueryProvider);
+
+    return Scaffold(
+      backgroundColor: Colors.grey.shade50,
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        title: Text(
+          'Tour Plans',
+          style: TextStyle(
+            color: AppColors.textdark,
+            fontSize: 20.sp,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: AppColors.textdark),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: Stack(
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: SvgPicture.asset(
+              'assets/images/corner_bubble.svg',
+              fit: BoxFit.cover,
+              height: 180.h,
+            ),
+          ),
+          Column(
+            children: [
+              Container(
+                height: 120.h,
+                color: Colors.transparent,
+              ),
+              // Search Bar Section - Matched to Expense Claims
+              Padding(
+                padding: EdgeInsets.fromLTRB(16.w, 8.h, 16.w, 16.h),
+                child: TextField(
+                  controller: _searchController,
+                  onChanged: (v) => ref.read(tourSearchQueryProvider.notifier).update(v),
+                  decoration: InputDecoration(
+                    hintText: 'Search tours',
+                    hintStyle: TextStyle(
+                      color: Colors.grey.shade400,
+                      fontSize: 14.sp,
+                      fontFamily: 'Poppins',
+                    ),
+                    prefixIcon: Icon(
+                      Icons.search,
+                      color: Colors.grey.shade400,
+                      size: 20.sp,
+                    ),
+                    suffixIcon: searchQuery.isNotEmpty
+                        ? IconButton(
+                      icon: Icon(Icons.clear, color: Colors.grey.shade400, size: 20.sp),
+                      onPressed: () {
+                        _searchController.clear();
+                        ref.read(tourSearchQueryProvider.notifier).update('');
+                      },
+                    )
+                        : null,
+                    filled: true,
+                    fillColor: Colors.white,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12.r),
+                      borderSide: BorderSide.none,
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12.r),
+                      borderSide: BorderSide(color: Colors.grey.shade200),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12.r),
+                      borderSide: const BorderSide(color: AppColors.primary, width: 2),
+                    ),
+                    contentPadding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 12.h),
+                  ),
+                ),
+              ),
+
+              // Filter Dropdown - Matched to Expense Claims
+              _buildFilterDropdown(),
+
+              SizedBox(height: 12.h),
+
+              Container(
+                color: Colors.transparent,
+                padding: EdgeInsets.fromLTRB(16.w, 0, 16.w, 12.h),
+                child: Row(
+                  children: [
+                    Text(
+                      'My Plans',
+                      style: TextStyle(
+                        fontSize: 16.sp,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.textdark,
+                        fontFamily: 'Poppins',
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              Expanded(
+                child: tourPlansAsync.when(
+                  data: (plans) {
+                    final filtered = _applyStatusFilter(plans);
+                    if (filtered.isEmpty) {
+                      return Center(child: Text("No tour plans found"));
+                    }
+                    return RefreshIndicator(
+                      onRefresh: () => ref.read(tourPlanViewModelProvider.notifier).refresh(),
+                      color: AppColors.primary,
+                      child: ListView.separated(
+                        padding: EdgeInsets.fromLTRB(16.w, 8.h, 16.w, 80.h),
+                        itemCount: filtered.length,
+                        separatorBuilder: (_, __) => SizedBox(height: 12.h),
+                        itemBuilder: (context, index) => _buildTourCard(filtered[index]),
+                      ),
+                    );
+                  },
+                  loading: () => Skeletonizer(
+                    enabled: true,
+                    child: ListView.separated(
+                      padding: EdgeInsets.fromLTRB(16.w, 8.h, 16.w, 80.h),
+                      itemCount: 5,
+                      separatorBuilder: (_, __) => SizedBox(height: 12.h),
+                      itemBuilder: (context, index) {
+                        return Container(
+                          height: 130.h,
+                          width: double.infinity,
+                          decoration: BoxDecoration(
+                            color: Colors.white,
+                            borderRadius: BorderRadius.circular(16.r),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  error: (e, _) => Center(child: Text('Error: $e')),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.push('/add-tour'),
+        backgroundColor: AppColors.primary,
+        elevation: 4,
+        icon: Icon(Icons.add, color: Colors.white, size: 20.sp),
+        label: Text(
+          'Add Tour',
+          style: TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.w600,
+            fontFamily: 'Poppins',
+            fontSize: 14.sp,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTourCard(TourPlanListItem plan) {
+    final statusColor = _getStatusColor(plan.status);
+
+    return GestureDetector(
+      onTap: () => context.pushNamed('edit-tour', pathParameters: {'tourId': plan.id}),
+      child: Container(
+        padding: EdgeInsets.all(16.w),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16.r),
+          border: Border.all(color: Colors.grey.shade100),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.03),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Row 1: Title and Status Tag
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Text(
+                    plan.placeOfVisit,
+                    style: TextStyle(
+                      fontSize: 16.sp,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.textdark,
+                      fontFamily: 'Poppins',
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                Container(
+                  padding: EdgeInsets.symmetric(horizontal: 10.w, vertical: 4.h),
+                  decoration: BoxDecoration(
+                    color: statusColor.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(20.r),
+                  ),
+                  child: Text(
+                    plan.status.isNotEmpty
+                        ? '${plan.status[0].toUpperCase()}${plan.status.substring(1)}'
+                        : '',
+                    style: TextStyle(
+                      color: statusColor,
+                      fontSize: 12.sp,
+                      fontWeight: FontWeight.w600,
+                      fontFamily: 'Poppins',
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 12.h),
+
+            // Row 2: Date Range
+            Row(
+              children: [
+                Icon(
+                  Icons.calendar_today_outlined,
+                  size: 16.sp,
+                  color: Colors.grey.shade400,
+                ),
+                SizedBox(width: 8.w),
+                Text(
+                  _formatDateRange(plan.startDate, plan.endDate),
+                  style: TextStyle(
+                    fontSize: 14.sp,
+                    color: Colors.grey.shade500,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(height: 8.h),
+
+            // Row 3: Duration
+            Row(
+              children: [
+                Icon(
+                  Icons.access_time,
+                  size: 16.sp,
+                  color: Colors.grey.shade400,
+                ),
+                SizedBox(width: 8.w),
+                Text(
+                  '${plan.durationDays} days',
+                  style: TextStyle(
+                    fontSize: 14.sp,
+                    color: Colors.grey.shade500,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<TourPlanListItem> _applyStatusFilter(List<TourPlanListItem> plans) {
+    if (_activeFilter == TourFilter.all) return plans;
+    return plans.where((p) => p.status.toLowerCase() == _activeFilter.name).toList();
+  }
+
+  Widget _buildFilterDropdown() {
+    return Container(
+      margin: EdgeInsets.symmetric(horizontal: 16.w),
+      padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 4.h),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12.r),
+        border: Border.all(color: AppColors.primary.withValues(alpha: 0.3)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.filter_list, size: 20.sp, color: AppColors.primary),
+          SizedBox(width: 12.w),
+          Text(
+            'Filter:',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w600,
+              color: AppColors.textdark,
+            ),
+          ),
+          SizedBox(width: 12.w),
+          Expanded(
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<TourFilter>(
+                value: _activeFilter,
+                isExpanded: true,
+                icon: Icon(
+                  Icons.keyboard_arrow_down,
+                  color: AppColors.primary,
+                  size: 24.sp,
+                ),
+                style: TextStyle(
+                  fontSize: 14.sp,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.primary,
+                ),
+                dropdownColor: Colors.white,
+                borderRadius: BorderRadius.circular(12.r),
+                items: [
+                  DropdownMenuItem(
+                    value: TourFilter.all,
+                    child: Row(
+                      children: [
+                        Icon(Icons.list, size: 18.sp, color: AppColors.textdark),
+                        SizedBox(width: 8.w),
+                        const Text('All Plans'),
+                      ],
+                    ),
+                  ),
+                  DropdownMenuItem(
+                    value: TourFilter.pending,
+                    child: Row(
+                      children: [
+                        Icon(Icons.pending, size: 18.sp, color: Colors.orange),
+                        SizedBox(width: 8.w),
+                        const Text('Pending'),
+                      ],
+                    ),
+                  ),
+                  DropdownMenuItem(
+                    value: TourFilter.approved,
+                    child: Row(
+                      children: [
+                        Icon(Icons.check_circle, size: 18.sp, color: Colors.green),
+                        SizedBox(width: 8.w),
+                        const Text('Approved'),
+                      ],
+                    ),
+                  ),
+                  DropdownMenuItem(
+                    value: TourFilter.rejected,
+                    child: Row(
+                      children: [
+                        Icon(Icons.cancel, size: 18.sp, color: Colors.red),
+                        SizedBox(width: 8.w),
+                        const Text('Rejected'),
+                      ],
+                    ),
+                  ),
+                ],
+                onChanged: (TourFilter? newFilter) {
+                  if (newFilter != null) {
+                    setState(() {
+                      _activeFilter = newFilter;
+                    });
+                  }
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/tour_plan/vm/add_tour.vm.dart
+++ b/lib/features/tour_plan/vm/add_tour.vm.dart
@@ -1,0 +1,37 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:sales_sphere/core/utils/logger.dart';
+import '../models/add_tour.models.dart';
+
+part 'add_tour.vm.g.dart';
+
+@riverpod
+class AddTourViewModel extends _$AddTourViewModel {
+  @override
+  FutureOr<void> build() {
+    return null;
+  }
+
+  Future<bool> saveTourPlanLocally(CreateTourRequest request) async {
+    state = const AsyncLoading();
+
+    try {
+      AppLogger.i('Frontend: Saving tour plan for ${request.placeOfVisit}');
+
+      await Future.delayed(const Duration(milliseconds: 500));
+
+      state = const AsyncData(null);
+      return true;
+    } catch (e, stack) {
+      state = AsyncError(e, stack);
+      return false;
+    }
+  }
+
+  // Validation helpers matching your Party VM logic
+  String? validateRequired(String? value, String fieldName) {
+    if (value == null || value.trim().isEmpty) {
+      return '$fieldName is required';
+    }
+    return null;
+  }
+}

--- a/lib/features/tour_plan/vm/edit_tour.vm.dart
+++ b/lib/features/tour_plan/vm/edit_tour.vm.dart
@@ -1,0 +1,39 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:sales_sphere/core/utils/logger.dart';
+import 'package:sales_sphere/features/tour_plan/models/edit_tour.model.dart';
+
+part 'edit_tour.vm.g.dart';
+
+@riverpod
+class EditTourViewModel extends _$EditTourViewModel {
+  @override
+  FutureOr<void> build() => null;
+
+  // Mock fetch - replace with dio.get(ApiEndpoints.tourById(id)) later
+  Future<TourDetails?> getTourById(String id) async {
+    AppLogger.i('Fetching tour details for ID: $id');
+    await Future.delayed(const Duration(milliseconds: 500));
+
+    // Returning dummy data for frontend development
+    return TourDetails(
+      id: id,
+      placeOfVisit: "Kathmandu, Nepal",
+      startDate: "2024-05-20",
+      endDate: "2024-05-25",
+      purposeOfVisit: "Client meeting and site inspection for new project.",
+      status: "Approved",
+    );
+  }
+
+  Future<void> updateTour(TourDetails updatedTour) async {
+    AppLogger.i('Updating tour: ${updatedTour.id}');
+    // Logic for Dio put request goes here
+    await Future.delayed(const Duration(seconds: 1));
+  }
+}
+
+@riverpod
+Future<TourDetails?> tourById(Ref ref, String tourId) async {
+  final vm = ref.read(editTourViewModelProvider.notifier);
+  return vm.getTourById(tourId);
+}

--- a/lib/features/tour_plan/vm/tour_plan.vm.dart
+++ b/lib/features/tour_plan/vm/tour_plan.vm.dart
@@ -1,0 +1,85 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:sales_sphere/core/utils/logger.dart';
+import '../models/tour_plan.model.dart';
+
+part 'tour_plan.vm.g.dart';
+
+@riverpod
+class TourPlanViewModel extends _$TourPlanViewModel {
+  @override
+  FutureOr<List<TourPlanListItem>> build() async {
+    return _fetchTourPlans();
+  }
+
+  Future<List<TourPlanListItem>> _fetchTourPlans() async {
+    AppLogger.i('📝 Fetching Mock Tour Plans');
+    await Future.delayed(const Duration(seconds: 1));
+
+    // Helper to calculate duration for mocks to match business logic (Inclusive)
+    int calc(String s, String e) {
+      final startDate = DateTime.parse(s);
+      final endDate = DateTime.parse(e);
+      return endDate.difference(startDate).inDays + 1;
+    }
+
+    return [
+      TourPlanListItem(
+        id: '1',
+        placeOfVisit: 'Singapore',
+        startDate: '2024-12-15',
+        endDate: '2024-12-22',
+        status: 'Approved',
+        durationDays: calc('2024-12-15', '2024-12-22'),
+      ),
+      TourPlanListItem(
+        id: '2',
+        placeOfVisit: 'New York, USA',
+        startDate: '2024-11-18',
+        endDate: '2024-11-20',
+        status: 'Pending',
+        durationDays: calc('2024-11-18', '2024-11-20'),
+      ),
+      TourPlanListItem(
+        id: '3',
+        placeOfVisit: 'London, UK',
+        startDate: '2024-11-15',
+        endDate: '2024-11-18',
+        status: 'Approved',
+        durationDays: calc('2024-11-15', '2024-11-18'),
+      ),
+      TourPlanListItem(
+        id: '4',
+        placeOfVisit: 'Bali, Indonesia',
+        startDate: '2024-11-12',
+        endDate: '2024-11-16',
+        status: 'Rejected',
+        durationDays: calc('2024-11-12', '2024-11-16'),
+      ),
+    ];
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => _fetchTourPlans());
+  }
+}
+
+@riverpod
+class TourSearchQuery extends _$TourSearchQuery {
+  @override
+  String build() => '';
+  void update(String query) => state = query;
+}
+
+@riverpod
+Future<List<TourPlanListItem>> filteredTourPlans(Ref ref) async {
+  final query = ref.watch(tourSearchQueryProvider).toLowerCase();
+  final tourPlans = await ref.watch(tourPlanViewModelProvider.future);
+
+  if (query.isEmpty) return tourPlans;
+
+  return tourPlans.where((plan) {
+    return plan.placeOfVisit.toLowerCase().contains(query) ||
+        plan.status.toLowerCase().contains(query);
+  }).toList();
+}

--- a/lib/features/utilities/views/utilities_screen.dart
+++ b/lib/features/utilities/views/utilities_screen.dart
@@ -130,7 +130,7 @@ class UtilitiesScreen extends ConsumerWidget {
                     subtitle: 'Plan and manage daily field visits',
                     icon: Icons.navigation_outlined,
                     iconColor: Color(0xFFFF9100),
-                    routePath: '/tour-plan',
+                    routePath: '/tour-plans',
                   ),
                   UtilityCard(
                     title: 'Attendance',


### PR DESCRIPTION
This pull request introduces the core data models and UI screens for the Tour Plan feature, and integrates new routes into the application's router. The main changes include the addition of models for creating, editing, and displaying tour plans, as well as the implementation of the Add Tour and Edit Tour Details screens. Routing logic has been updated to support navigation to these new screens.

**Tour Plan Feature Implementation**

* Added data models for tour plan creation, editing, and API response handling using `freezed` and `json_serializable`. This includes `CreateTourRequest`, `TourListItem`, `TourDetails`, `UpdateTourRequest`, and models for API responses and list items. [[1]](diffhunk://#diff-87ab5e25bfb5b2f5c7c92fd7e6d35bc3a4a41edbd46442b22e6f40488838e0a7R1-R31) [[2]](diffhunk://#diff-adebc5ac790a5b19d50c873806958cc1936535e2c9403a4af477104a7a395611R1-R55) [[3]](diffhunk://#diff-326892480efc3167b1d1373cdb5238b95e8fcc11552fd70ce8d72fec5d983e0aR1-R70)
* Implemented `AddTourPlanScreen` for creating a new tour plan, including form validation and local state management.
* Implemented `EditTourDetailsScreen` for viewing and editing an existing tour plan, with support for read-only and editable modes based on status.

**Routing Updates**

* Updated `route_handler.dart` to add new routes for `/tour-plans`, `/add-tour`, and `/edit-tour/:tourId`, and adjusted login logic to allow unauthenticated access to these routes as needed. [[1]](diffhunk://#diff-8e35ddc744e3a4ceda5c9c026829c2624b64cd6213077f352b985264c2e478d6R4-R6) [[2]](diffhunk://#diff-8e35ddc744e3a4ceda5c9c026829c2624b64cd6213077f352b985264c2e478d6R112-R114) [[3]](diffhunk://#diff-8e35ddc744e3a4ceda5c9c026829c2624b64cd6213077f352b985264c2e478d6L132-R141) [[4]](diffhunk://#diff-8e35ddc744e3a4ceda5c9c026829c2624b64cd6213077f352b985264c2e478d6R343-R364)