### PR TITLE
Enhanced the UI of collection screens.

### DIFF
--- a/lib/features/collection/views/edit_collection_screen.dart
+++ b/lib/features/collection/views/edit_collection_screen.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
 import 'package:sales_sphere/core/constants/app_colors.dart';
 import 'package:sales_sphere/widget/custom_text_field.dart';
 import 'package:sales_sphere/widget/custom_button.dart';
@@ -13,7 +13,6 @@ import 'package:sales_sphere/widget/custom_date_picker.dart';
 import 'package:sales_sphere/features/collection/models/collection.model.dart';
 import 'package:sales_sphere/features/collection/vm/collection.vm.dart';
 import 'package:sales_sphere/features/collection/vm/edit_collection.vm.dart';
-import 'package:sales_sphere/core/utils/logger.dart';
 
 class EditCollectionScreen extends ConsumerStatefulWidget {
   final String collectionId;
@@ -26,6 +25,13 @@ class EditCollectionScreen extends ConsumerStatefulWidget {
 
 class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
   final _formKey = GlobalKey<FormState>();
+
+  // LayerLinks for attached dropdown alignment
+  final LayerLink _partyLink = LayerLink();
+  final LayerLink _paymentLink = LayerLink();
+  final LayerLink _bankLink = LayerLink();
+  final LayerLink _statusLink = LayerLink();
+  OverlayEntry? _overlayEntry;
 
   // Controllers
   late TextEditingController _amountController;
@@ -42,7 +48,6 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
   bool _isEditMode = false;
   bool _isDataLoaded = false;
 
-  // Image Handling
   final List<XFile> _selectedImages = [];
   final ImagePicker _picker = ImagePicker();
 
@@ -57,26 +62,31 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
     _descriptionController = TextEditingController();
   }
 
-  /// FIXED: Prefill images from local paths to solve "image not coming" issue
   void _prefillData(CollectionListItem data) {
     _amountController.text = data.amount.toString();
-    _dateController.text = data.date;
+
+    try {
+      final dateTime = DateTime.parse(data.date);
+      _dateController.text = DateFormat('dd MMM yyyy').format(dateTime);
+    } catch (e) {
+      _dateController.text = data.date;
+    }
+
     _paymentMode = data.paymentMode;
     _descriptionController.text = data.remarks ?? '';
     _selectedPartyId = data.partyName;
 
-    // Check if the item has stored image paths and convert them to XFiles for the UI
     if (data.imagePaths != null && data.imagePaths!.isNotEmpty) {
       _selectedImages.clear();
       for (var path in data.imagePaths!) {
         _selectedImages.add(XFile(path));
       }
-      AppLogger.i('📸 Prefilled ${_selectedImages.length} images from local paths');
     }
   }
 
   @override
   void dispose() {
+    _hideDropdown();
     _amountController.dispose();
     _dateController.dispose();
     _bankNameController.dispose();
@@ -86,91 +96,151 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
     super.dispose();
   }
 
-  // --- IMAGE PICKER LOGIC ---
-  Future<void> _pickImage() async {
-    if (_selectedImages.length >= 2) return;
-
-    try {
-      showModalBottomSheet(
-        context: context,
-        builder: (BuildContext context) {
-          return SafeArea(
-            child: Wrap(
-              children: <Widget>[
-                ListTile(
-                  leading: const Icon(Icons.photo_library),
-                  title: const Text('Gallery'),
-                  onTap: () async {
-                    context.pop();
-                    final XFile? image = await _picker.pickImage(
-                        source: ImageSource.gallery, imageQuality: 70);
-                    if (image != null) setState(() => _selectedImages.add(image));
-                  },
-                ),
-                ListTile(
-                  leading: const Icon(Icons.photo_camera),
-                  title: const Text('Camera'),
-                  onTap: () async {
-                    context.pop();
-                    final XFile? image = await _picker.pickImage(
-                        source: ImageSource.camera, imageQuality: 70);
-                    if (image != null) setState(() => _selectedImages.add(image));
-                  },
-                ),
-              ],
-            ),
-          );
-        },
-      );
-    } catch (e) {
-      debugPrint("Error picking image: $e");
-    }
+  void _hideDropdown() {
+    _overlayEntry?.remove();
+    _overlayEntry = null;
   }
 
-  // --- IMAGE PREVIEW & ZOOM LOGIC ---
+  // FIXED DROPDOWN OVERLAY LOGIC
+  void _showSearchableDropdown({
+    required LayerLink link,
+    required List<String> items,
+    required String? currentValue,
+    required String searchHint,
+    required Function(String) onSelected,
+    bool isSearchable = false,
+  }) {
+    _hideDropdown();
+    String searchQuery = "";
+
+    _overlayEntry = OverlayEntry(
+      builder: (context) => Stack(
+        children: [
+          GestureDetector(
+            onTap: _hideDropdown,
+            behavior: HitTestBehavior.translucent,
+            child: Container(color: Colors.transparent),
+          ),
+          Positioned(
+            width: MediaQuery.of(context).size.width - 64.w,
+            child: CompositedTransformFollower(
+              link: link,
+              showWhenUnlinked: false,
+              offset: Offset(0, 52.h),
+              child: Material(
+                elevation: 12,
+                borderRadius: BorderRadius.circular(12.r),
+                color: Colors.white,
+                child: StatefulBuilder(
+                  builder: (context, setOverlayState) {
+                    final filteredItems = items
+                        .where((item) => item.toLowerCase().contains(searchQuery.toLowerCase()))
+                        .toList();
+
+                    return Container(
+                      constraints: BoxConstraints(maxHeight: 250.h),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(12.r),
+                        border: Border.all(color: Colors.grey.shade200),
+                      ),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (isSearchable)
+                            Padding(
+                              padding: EdgeInsets.all(8.w),
+                              child: TextField(
+                                autofocus: true,
+                                style: TextStyle(fontFamily: 'Poppins', fontSize: 14.sp),
+                                decoration: InputDecoration(
+                                  hintText: searchHint,
+                                  prefixIcon: Icon(Icons.search, size: 18.sp),
+                                  isDense: true,
+                                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(8.r)),
+                                ),
+                                onChanged: (val) => setOverlayState(() => searchQuery = val),
+                              ),
+                            ),
+                          Flexible(
+                            child: ListView.builder(
+                              padding: EdgeInsets.zero,
+                              shrinkWrap: true,
+                              itemCount: filteredItems.length,
+                              itemBuilder: (context, index) {
+                                final item = filteredItems[index];
+                                final bool isSelected = currentValue == item;
+                                return ListTile(
+                                  dense: true,
+                                  title: Text(item, style: TextStyle(fontFamily: 'Poppins', fontSize: 14.sp)),
+                                  trailing: isSelected
+                                      ? Icon(Icons.check, color: AppColors.primary, size: 20.sp)
+                                      : null,
+                                  onTap: () {
+                                    onSelected(item);
+                                    _hideDropdown();
+                                  },
+                                );
+                              },
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    Overlay.of(context).insert(_overlayEntry!);
+  }
+
   void _showImagePreview(XFile imageFile) {
     showDialog(
       context: context,
-      builder: (BuildContext context) {
-        return Dialog(
-          backgroundColor: Colors.transparent,
-          insetPadding: EdgeInsets.all(16.w),
-          child: Stack(
+      builder: (context) => Dialog(
+        backgroundColor: Colors.transparent,
+        insetPadding: EdgeInsets.all(16.w),
+        child: Stack(
+          children: [
+            InteractiveViewer(child: ClipRRect(borderRadius: BorderRadius.circular(12.r), child: Image.file(File(imageFile.path)))),
+            Positioned(top: 0, right: 0, child: GestureDetector(onTap: () => context.pop(), child: Container(padding: EdgeInsets.all(8.w), decoration: const BoxDecoration(color: Colors.black54, shape: BoxShape.circle), child: Icon(Icons.close, color: Colors.white, size: 24.sp)))),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickImage() async {
+    if (_selectedImages.length >= 2) return;
+    try {
+      showModalBottomSheet(
+        context: context,
+        builder: (context) => SafeArea(
+          child: Wrap(
             children: [
-              Container(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.of(context).size.height * 0.8,
-                  maxWidth: MediaQuery.of(context).size.width,
-                ),
-                child: InteractiveViewer(
-                  minScale: 0.5,
-                  maxScale: 4.0,
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(12.r),
-                    child: Image.file(File(imageFile.path), fit: BoxFit.contain),
-                  ),
-                ),
-              ),
-              Positioned(
-                top: 0, right: 0,
-                child: GestureDetector(
-                  onTap: () => context.pop(),
-                  child: Container(
-                    padding: EdgeInsets.all(8.w),
-                    decoration: const BoxDecoration(color: Colors.black54, shape: BoxShape.circle),
-                    child: Icon(Icons.close, color: Colors.white, size: 24.sp),
-                  ),
-                ),
-              ),
+              ListTile(leading: const Icon(Icons.photo_library), title: const Text('Gallery'), onTap: () async { context.pop(); final XFile? img = await _picker.pickImage(source: ImageSource.gallery, imageQuality: 70); if (img != null) setState(() => _selectedImages.add(img)); }),
+              ListTile(leading: const Icon(Icons.photo_camera), title: const Text('Camera'), onTap: () async { context.pop(); final XFile? img = await _picker.pickImage(source: ImageSource.camera, imageQuality: 70); if (img != null) setState(() => _selectedImages.add(img)); }),
             ],
           ),
-        );
-      },
-    );
+        ),
+      );
+    } catch (e) { debugPrint("Error: $e"); }
   }
 
   Future<void> _handleUpdate() async {
     if (_formKey.currentState?.validate() ?? false) {
+      final bool imageRequired = ['Cheque', 'Bank Transfer', 'QR Pay'].contains(_paymentMode);
+      if (imageRequired && _selectedImages.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text('Please upload an image for $_paymentMode payment'),
+          backgroundColor: AppColors.primary,
+        ));
+        return;
+      }
+
       try {
         final vm = ref.read(editCollectionViewModelProvider.notifier);
         final updateData = {
@@ -186,7 +256,11 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
           },
         };
 
-        await vm.updateCollection(collectionId: widget.collectionId, data: updateData);
+        await vm.updateCollection(
+          collectionId: widget.collectionId,
+          data: updateData,
+          imagePaths: _selectedImages.map((e) => e.path).toList(),
+        );
 
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Collection Updated Successfully'), backgroundColor: Colors.green));
@@ -202,6 +276,7 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
   @override
   Widget build(BuildContext context) {
     final collectionsAsync = ref.watch(collectionViewModelProvider);
+    final bool requiresImage = ['Cheque', 'Bank Transfer', 'QR Pay'].contains(_paymentMode);
 
     return collectionsAsync.when(
       data: (list) {
@@ -218,106 +293,112 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
           appBar: AppBar(
             backgroundColor: Colors.transparent,
             elevation: 0,
-            centerTitle: false, // Left Aligned Heading
-            title: Text("Details", style: TextStyle(color: AppColors.textdark, fontSize: 18.sp, fontWeight: FontWeight.w600, fontFamily: 'Poppins')),
+            title: Text("Collection Details", style: TextStyle(color: AppColors.textdark, fontSize: 18.sp, fontWeight: FontWeight.w600, fontFamily: 'Poppins')),
             leading: IconButton(icon: const Icon(Icons.arrow_back, color: AppColors.textdark), onPressed: () => context.pop()),
             actions: [
               if (_isEditMode)
                 TextButton(
                   onPressed: () {
-                    setState(() {
-                      _isEditMode = false;
-                      _prefillData(item); // Reset images and fields
-                    });
+                    setState(() { _isEditMode = false; _prefillData(item); });
                   },
                   child: Text('Cancel', style: TextStyle(color: AppColors.error, fontSize: 14.sp, fontWeight: FontWeight.w500)),
                 ),
             ],
           ),
-          body: Stack(
-            children: [
-              Positioned(top: 0, left: 0, right: 0, child: SvgPicture.asset('assets/images/corner_bubble.svg', fit: BoxFit.cover, height: 180.h)),
-              Column(
-                children: [
-                  Expanded(
-                    child: SingleChildScrollView(
-                      padding: EdgeInsets.symmetric(horizontal: 16.w),
-                      child: Padding(
-                        padding: EdgeInsets.only(top: 100.h, bottom: 16.h),
-                        child: Form(
-                          key: _formKey,
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Container(
-                                width: double.infinity,
-                                padding: EdgeInsets.all(14.w),
-                                decoration: BoxDecoration(
-                                  color: Colors.white,
-                                  borderRadius: BorderRadius.circular(16.r),
-                                  boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.04), blurRadius: 10, offset: const Offset(0, 2))],
-                                ),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    // 1. Party Name
-                                    _buildSelectionDropdown(label: "Party Name", value: _selectedPartyId, icon: Icons.people_outline, enabled: false),
-                                    SizedBox(height: 16.h),
-
-                                    // 2. Amount
-                                    PrimaryTextField(controller: _amountController, hintText: "Amount Received", prefixIcon: Icons.currency_rupee, enabled: _isEditMode, keyboardType: TextInputType.number),
-                                    SizedBox(height: 16.h),
-
-                                    // 3. Date
-                                    CustomDatePicker(controller: _dateController, hintText: "Received Date", prefixIcon: Icons.calendar_today_outlined, enabled: _isEditMode),
-                                    SizedBox(height: 16.h),
-
-                                    // 4. Payment Mode
-                                    _buildPaymentModeDropdown(),
-
-                                    if (_paymentMode == 'Cheque' || _paymentMode == 'Bank Transfer') ...[
+          body: GestureDetector(
+            onTap: () { FocusScope.of(context).unfocus(); _hideDropdown(); },
+            child: Stack(
+              children: [
+                Positioned(top: 0, left: 0, right: 0, child: SvgPicture.asset('assets/images/corner_bubble.svg', fit: BoxFit.cover, height: 180.h)),
+                Column(
+                  children: [
+                    Expanded(
+                      child: SingleChildScrollView(
+                        padding: EdgeInsets.symmetric(horizontal: 16.w),
+                        child: Column(
+                          children: [
+                            Padding(
+                              padding: EdgeInsets.only(top: 100.h, bottom: 16.h),
+                              child: Form(
+                                key: _formKey,
+                                child: Container(
+                                  width: double.infinity,
+                                  padding: EdgeInsets.all(14.w),
+                                  decoration: BoxDecoration(
+                                    color: Colors.white,
+                                    borderRadius: BorderRadius.circular(16.r),
+                                    boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.04), blurRadius: 10, offset: const Offset(0, 2))],
+                                  ),
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      _buildDropdown("Party Name", _selectedPartyId, Icons.people_outline, () {
+                                        _showSearchableDropdown(
+                                          link: _partyLink, items: ["Party A", "Party B", "Mock Party"], currentValue: _selectedPartyId,
+                                          searchHint: "Search party...", isSearchable: true, onSelected: (val) => setState(() => _selectedPartyId = val),
+                                        );
+                                      }, _isEditMode, _partyLink),
                                       SizedBox(height: 16.h),
-                                      PrimaryTextField(controller: _bankNameController, hintText: "Bank Name", prefixIcon: Icons.account_balance_outlined, enabled: _isEditMode),
+                                      PrimaryTextField(controller: _amountController, hintText: "Amount Received", prefixIcon: Icons.currency_rupee, enabled: _isEditMode, keyboardType: TextInputType.number, validator: (v) => v!.isEmpty ? 'Required' : null),
+                                      SizedBox(height: 16.h),
+                                      CustomDatePicker(controller: _dateController, hintText: "Received Date", prefixIcon: Icons.calendar_today_outlined, enabled: _isEditMode),
+                                      SizedBox(height: 16.h),
+                                      _buildDropdown("Payment Mode", _paymentMode, Icons.credit_card_outlined, () {
+                                        _showSearchableDropdown(
+                                          link: _paymentLink, items: ['Cash', 'Cheque', 'Bank Transfer', 'QR Pay'], currentValue: _paymentMode,
+                                          searchHint: "", onSelected: (val) => setState(() { _paymentMode = val; _bankNameController.clear(); _chequeNoController.clear(); }),
+                                        );
+                                      }, _isEditMode, _paymentLink),
+
+                                      if (_paymentMode == 'Cheque' || _paymentMode == 'Bank Transfer') ...[
+                                        SizedBox(height: 16.h),
+                                        _buildDropdown("Select Bank", _bankNameController.text.isEmpty ? null : _bankNameController.text, Icons.account_balance_outlined, () {
+                                          _showSearchableDropdown(
+                                            link: _bankLink, items: ["HDFC Bank", "ICICI Bank", "SBI", "Axis Bank"], currentValue: _bankNameController.text,
+                                            searchHint: "Search bank...", isSearchable: true, onSelected: (val) => setState(() => _bankNameController.text = val),
+                                          );
+                                        }, _isEditMode, _bankLink),
+                                      ],
+
+                                      if (_paymentMode == 'Cheque') ...[
+                                        SizedBox(height: 16.h),
+                                        PrimaryTextField(controller: _chequeNoController, hintText: "Cheque Number", prefixIcon: Icons.numbers_outlined, enabled: _isEditMode, validator: (v) => v!.isEmpty ? 'Required' : null),
+                                        SizedBox(height: 16.h),
+                                        CustomDatePicker(controller: _chequeDateController, hintText: "Date of Cheque", prefixIcon: Icons.calendar_today_outlined, enabled: _isEditMode),
+                                        SizedBox(height: 16.h),
+                                        _buildDropdown("Cheque Status", _chequeStatus, Icons.assignment_outlined, () {
+                                          _showSearchableDropdown(
+                                            link: _statusLink, items: ['Pending', 'Deposited', 'Cleared', 'Bounced'], currentValue: _chequeStatus,
+                                            searchHint: "", onSelected: (val) => setState(() => _chequeStatus = val),
+                                          );
+                                        }, _isEditMode, _statusLink),
+                                      ],
+
+                                      SizedBox(height: 16.h),
+                                      PrimaryTextField(controller: _descriptionController, hintText: "Description", prefixIcon: Icons.description_outlined, enabled: _isEditMode, maxLines: 5, minLines: 1),
+
+                                      if (requiresImage || _selectedImages.isNotEmpty) ...[
+                                        SizedBox(height: 20.h),
+                                        Text("Collection Images", style: TextStyle(fontSize: 12.sp, fontWeight: FontWeight.w500, color: Colors.grey.shade600, fontFamily: 'Poppins')),
+                                        SizedBox(height: 8.h),
+                                        _buildImageSection(),
+                                      ],
                                     ],
-                                    if (_paymentMode == 'Cheque') ...[
-                                      SizedBox(height: 16.h),
-                                      PrimaryTextField(controller: _chequeNoController, hintText: "Cheque Number", prefixIcon: Icons.numbers_outlined, enabled: _isEditMode),
-                                      SizedBox(height: 16.h),
-                                      _buildChequeStatusDropdown(),
-                                    ],
-
-                                    SizedBox(height: 16.h),
-
-                                    // 5. Description
-                                    PrimaryTextField(
-                                      controller: _descriptionController,
-                                      hintText: "Description",
-                                      prefixIcon: Icons.description_outlined,
-                                      enabled: _isEditMode,
-                                      maxLines: 5,
-                                      minLines: 1,
-                                      textInputAction: TextInputAction.newline,
-                                    ),
-                                    SizedBox(height: 20.h),
-
-                                    // 6. Image Section
-                                    Text("Collection Images", style: TextStyle(fontSize: 12.sp, fontWeight: FontWeight.w500, color: Colors.grey.shade600, fontFamily: 'Poppins')),
-                                    SizedBox(height: 8.h),
-                                    _buildImageSection(),
-                                  ],
+                                  ),
                                 ),
                               ),
-                              SizedBox(height: 80.h),
-                            ],
-                          ),
+                            ),
+                            // KEYBOARD BUFFER FIX
+                            SizedBox(height: MediaQuery.of(context).viewInsets.bottom > 0 ? 320.h : 100.h),
+                          ],
                         ),
                       ),
                     ),
-                  ),
-                  _buildBottomButton(),
-                ],
-              ),
-            ],
+                    _buildBottomButton(),
+                  ],
+                ),
+              ],
+            ),
           ),
         );
       },
@@ -325,8 +406,6 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
       error: (e, _) => Scaffold(body: Center(child: Text('Error: $e'))),
     );
   }
-
-  // --- Helper Widgets ---
 
   Widget _buildBottomButton() {
     return Container(
@@ -343,42 +422,35 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
 
   Widget _buildImageSection() {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (_selectedImages.isNotEmpty)
-          ListView.builder(
+          ListView.separated(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
             itemCount: _selectedImages.length,
-            itemBuilder: (context, index) {
-              return Padding(
-                padding: EdgeInsets.only(bottom: 12.h),
-                child: _buildImageThumbnail(_selectedImages[index], index),
-              );
-            },
+            separatorBuilder: (context, index) => SizedBox(height: 12.h),
+            itemBuilder: (context, index) => _buildImageThumbnail(_selectedImages[index], index),
           ),
 
-        if (_selectedImages.length < 2 && _isEditMode)
+        if (_isEditMode && _selectedImages.length < 2) ...[
+          if (_selectedImages.isNotEmpty) SizedBox(height: 16.h),
           GestureDetector(
             onTap: _pickImage,
             child: Container(
-              height: 100.h,
-              width: double.infinity,
-              decoration: BoxDecoration(
-                color: const Color(0xFFF5F6FA),
-                borderRadius: BorderRadius.circular(12.r),
-                border: Border.all(color: const Color(0xFFE0E0E0)),
-              ),
+              height: 100.h, width: double.infinity,
+              decoration: BoxDecoration(color: const Color(0xFFF5F6FA), borderRadius: BorderRadius.circular(12.r), border: Border.all(color: const Color(0xFFE0E0E0))),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Icon(Icons.add_photo_alternate_outlined, size: 32.sp, color: Colors.grey.shade400),
-                  SizedBox(height: 4.h),
-                  Text("Tap to add collection image (${_selectedImages.length}/2)",
-                      style: TextStyle(fontSize: 12.sp, color: Colors.grey.shade600, fontFamily: 'Poppins')),
+                  SizedBox(height: 8.h),
+                  Text("Tap to add collection image (${_selectedImages.length}/2)", style: TextStyle(fontSize: 12.sp, color: Colors.grey.shade600, fontFamily: 'Poppins')),
                 ],
               ),
             ),
           ),
+        ],
       ],
     );
   }
@@ -388,10 +460,7 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
       onTap: () => _showImagePreview(imageFile),
       child: Stack(
         children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(12.r),
-            child: Image.file(File(imageFile.path), width: double.infinity, height: 140.h, fit: BoxFit.cover),
-          ),
+          ClipRRect(borderRadius: BorderRadius.circular(12.r), child: Image.file(File(imageFile.path), width: double.infinity, height: 160.h, fit: BoxFit.cover)),
           Positioned(
             bottom: 8.h, right: 8.w,
             child: Container(
@@ -401,7 +470,6 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
                 children: [
                   Icon(Icons.zoom_in, color: Colors.white, size: 14.sp),
                   SizedBox(width: 4.w),
-                  // FIXED: Removed const to solve build error
                   Text('Preview', style: TextStyle(color: Colors.white, fontSize: 10.sp))
                 ],
               ),
@@ -412,79 +480,60 @@ class _EditCollectionScreenState extends ConsumerState<EditCollectionScreen> {
               top: 8.h, right: 8.w,
               child: GestureDetector(
                 onTap: () => setState(() => _selectedImages.removeAt(index)),
-                child: Container(
-                  padding: EdgeInsets.all(4.w),
-                  decoration: const BoxDecoration(color: Colors.black54, shape: BoxShape.circle),
-                  child: Icon(Icons.close, color: Colors.white, size: 16.sp),
+                child: Container(padding: EdgeInsets.all(4.w), decoration: const BoxDecoration(color: Colors.black54, shape: BoxShape.circle), child: Icon(Icons.close, color: Colors.white, size: 16.sp)),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDropdown(String label, String? value, IconData icon, VoidCallback onTap, bool enabled, LayerLink? link) {
+    Widget dropdown = FormField<String>(
+      validator: (v) => (value == null || value.isEmpty) ? '$label is required' : null,
+      builder: (state) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GestureDetector(
+              onTap: enabled ? onTap : null,
+              child: Container(
+                padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 14.h),
+                decoration: BoxDecoration(
+                    color: enabled ? Colors.white : Colors.grey.shade100,
+                    border: Border.all(
+                        color: state.hasError
+                            ? Colors.red
+                            : (enabled ? Colors.grey.shade300 : Colors.grey.shade200)
+                    ),
+                    borderRadius: BorderRadius.circular(12.r)
+                ),
+                child: Row(
+                  children: [
+                    Icon(icon, color: enabled ? Colors.grey.shade600 : Colors.grey.shade400, size: 20.sp),
+                    SizedBox(width: 12.w),
+                    Text(
+                        value ?? label,
+                        style: TextStyle(
+                            color: enabled
+                                ? (value != null ? Colors.black : Colors.grey.shade500)
+                                : Colors.grey.shade600,
+                            fontFamily: 'Poppins',
+                            fontSize: 14.sp
+                        )
+                    ),
+                    const Spacer(),
+                    if (enabled) const Icon(Icons.keyboard_arrow_down, color: Colors.grey),
+                  ],
                 ),
               ),
             ),
-        ],
-      ),
+            if (state.hasError) Padding(padding: EdgeInsets.only(top: 5.h, left: 12.w), child: Text(state.errorText!, style: TextStyle(color: Colors.red, fontSize: 12.sp))),
+          ],
+        );
+      },
     );
-  }
 
-  Widget _buildPaymentModeDropdown() {
-    return _buildDropdownField(
-      label: "Payment Mode",
-      value: _paymentMode,
-      enabled: _isEditMode,
-      icon: Icons.payments_outlined,
-      items: ['Cash', 'Cheque', 'Bank Transfer', 'QR Pay', 'Others'],
-      onChanged: (val) => setState(() => _paymentMode = val),
-    );
-  }
-
-  Widget _buildChequeStatusDropdown() {
-    return _buildDropdownField(
-      label: "Cheque Status",
-      value: _chequeStatus,
-      enabled: _isEditMode,
-      icon: Icons.assignment_outlined,
-      items: ['Pending', 'Deposited', 'Cleared', 'Bounced'],
-      onChanged: (val) => setState(() => _chequeStatus = val),
-    );
-  }
-
-  Widget _buildDropdownField({required String label, String? value, required bool enabled, required IconData icon, required List<String> items, required Function(String?) onChanged}) {
-    return Container(
-      padding: EdgeInsets.symmetric(horizontal: 16.w),
-      decoration: BoxDecoration(
-        color: enabled ? Colors.white : Colors.grey.shade100,
-        borderRadius: BorderRadius.circular(12.r),
-        border: Border.all(color: enabled ? AppColors.border : AppColors.border.withValues(alpha: 0.2), width: 1.5),
-      ),
-      child: Row(
-        children: [
-          Icon(icon, color: Colors.grey.shade600, size: 20.sp),
-          SizedBox(width: 12.w),
-          Expanded(
-            child: DropdownButtonHideUnderline(
-              child: DropdownButton<String>(
-                value: value,
-                isExpanded: true,
-                disabledHint: Text(value ?? label, style: TextStyle(color: AppColors.textSecondary.withValues(alpha: 0.6), fontFamily: 'Poppins')),
-                items: enabled ? items.map((e) => DropdownMenuItem(value: e, child: Text(e, style: const TextStyle(fontFamily: 'Poppins')))).toList() : null,
-                onChanged: enabled ? onChanged : null,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSelectionDropdown({required String label, String? value, required IconData icon, required bool enabled}) {
-    return Container(
-      padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 14.h),
-      decoration: BoxDecoration(color: Colors.grey.shade100, border: Border.all(color: AppColors.border.withValues(alpha: 0.2), width: 1.5), borderRadius: BorderRadius.circular(12.r)),
-      child: Row(
-        children: [
-          Icon(icon, color: Colors.grey.shade500, size: 20.sp),
-          SizedBox(width: 12.w),
-          Text(value ?? label, style: TextStyle(color: AppColors.textSecondary.withValues(alpha: 0.6), fontSize: 14.sp, fontFamily: 'Poppins')),
-        ],
-      ),
-    );
+    return link != null ? CompositedTransformTarget(link: link, child: dropdown) : dropdown;
   }
 }

--- a/lib/features/collection/vm/edit_collection.vm.dart
+++ b/lib/features/collection/vm/edit_collection.vm.dart
@@ -28,6 +28,7 @@ class EditCollectionViewModel extends _$EditCollectionViewModel {
   Future<void> updateCollection({
     required String collectionId,
     required Map<String, dynamic> data,
+    List<String>? imagePaths, // ADDED: To support persistent mock images
   }) async {
     _keepAlive();
     try {
@@ -38,7 +39,7 @@ class EditCollectionViewModel extends _$EditCollectionViewModel {
 
       if (!ref.mounted) return;
 
-      // Create the updated object
+      // Create the updated object including image paths
       final updatedItem = CollectionListItem(
         id: collectionId,
         partyName: data['party'] ?? 'Updated Party',
@@ -46,12 +47,13 @@ class EditCollectionViewModel extends _$EditCollectionViewModel {
         date: data['date'] ?? DateTime.now().toString(),
         paymentMode: data['paymentMode'] ?? 'Cash',
         remarks: data['description'],
+        imagePaths: imagePaths, // Pass image paths to the model
       );
 
       // Push change to the main list provider
       ref.read(collectionViewModelProvider.notifier).updateCollectionLocally(updatedItem);
 
-      AppLogger.i('✅ MOCK: Update successful in local state');
+      AppLogger.i('✅ MOCK: Update successful with ${imagePaths?.length ?? 0} images');
     } catch (e) {
       AppLogger.e('❌ MOCK Update Error: $e');
       rethrow;
@@ -60,10 +62,10 @@ class EditCollectionViewModel extends _$EditCollectionViewModel {
     }
   }
 
-  /// MOCK IMPLEMENTATION: Simulates image update
+  /// MOCK IMPLEMENTATION: Simulates image update locally
   Future<void> uploadCollectionImages(String collectionId, List<File> images) async {
     try {
-      AppLogger.i('📸 MOCK: Simulating image replacement for: $collectionId');
+      AppLogger.i('📸 MOCK: Simulating image upload for: $collectionId');
       await Future.delayed(const Duration(milliseconds: 500));
       if (ref.mounted) AppLogger.i('✅ MOCK: Image upload complete');
     } catch (e) {

--- a/lib/features/utilities/views/utilities_screen.dart
+++ b/lib/features/utilities/views/utilities_screen.dart
@@ -146,6 +146,13 @@ class UtilitiesScreen extends ConsumerWidget {
                     iconColor: Color(0xFF26A69A),
                     routePath: '/collections',
                   ),
+                  UtilityCard(
+                    title: 'Leave Request',
+                    subtitle: 'Apply for leaves and track approval status',
+                    icon: Icons.time_to_leave_rounded,
+                    iconColor: Color(0xFF303F9F),
+                    routePath: '/leave-requests',
+                  ),
                 ],
               ),
 


### PR DESCRIPTION
This pull request enhances the collections feature by improving support for handling images in mock updates and updates the utilities screen to include a new "Leave Request" option. The main changes focus on enabling persistent mock image handling in collection updates and expanding the application's utilities.

**Collections Feature Enhancements:**

* Added an optional `imagePaths` parameter to the `updateCollection` method in `EditCollectionViewModel` to support persistent mock images.
* Updated the creation of the `CollectionListItem` in `updateCollection` to include `imagePaths`, ensuring image data is passed and logged during mock updates.
* Improved logging and clarified the mock implementation for local image uploads, making the process and output messages more accurate.

**Utilities Screen Update:**

* Added a new `UtilityCard` for "Leave Request" to the `UtilitiesScreen`, allowing users to apply for leaves and track approval status.