### PR TITLE
enhancement: Beat-Plan Providers

### DIFF
--- a/lib/core/providers/location_tracking_provider.dart
+++ b/lib/core/providers/location_tracking_provider.dart
@@ -6,14 +6,16 @@ part 'location_tracking_provider.g.dart';
 
 /// Location Tracking Service Provider
 /// Provides access to the singleton location tracking service
-@riverpod
+/// NOTE: keepAlive is required to prevent service from being disposed during navigation
+@Riverpod(keepAlive: true)
 LocationTrackingService locationTrackingService(Ref ref) {
   final service = LocationTrackingService.instance;
 
-  // Cleanup when provider is disposed
+  // Cleanup when provider is disposed (only on logout/app shutdown)
   ref.onDispose(() {
     AppLogger.d('Disposing LocationTrackingService provider');
-    service.dispose();
+    // Don't dispose singleton - only dispose on logout/app shutdown
+    // service.dispose() is now called only when explicitly stopping tracking
   });
 
   return service;

--- a/lib/core/providers/tracking_socket_provider.dart
+++ b/lib/core/providers/tracking_socket_provider.dart
@@ -6,14 +6,16 @@ part 'tracking_socket_provider.g.dart';
 
 /// Tracking Socket Service Provider
 /// Provides access to the singleton tracking socket service
-@riverpod
+/// NOTE: keepAlive is required to prevent service from being disposed during navigation
+@Riverpod(keepAlive: true)
 TrackingSocketService trackingSocketService(Ref ref) {
   final service = TrackingSocketService.instance;
 
-  // Cleanup when provider is disposed
+  // Cleanup when provider is disposed (only on logout/app shutdown)
   ref.onDispose(() {
     AppLogger.d('Disposing TrackingSocketService provider');
-    service.dispose();
+    // Don't dispose singleton - only dispose on logout/app shutdown
+    // service.dispose() is now called only when explicitly stopping tracking
   });
 
   return service;

--- a/lib/core/services/background_tracking_service.dart
+++ b/lib/core/services/background_tracking_service.dart
@@ -476,12 +476,12 @@ class BackgroundTrackingService {
 
     await plugin.initialize(initializationSettings);
 
-    // Create notification channel
+    // Create notification channel with MAX importance to prevent dismissal (Uber-like)
     const AndroidNotificationChannel channel = AndroidNotificationChannel(
       _channelId,
       _channelName,
       description: 'Ongoing beat plan tracking notification',
-      importance: Importance.low,
+      importance: Importance.max,  // MAX importance - truly non-dismissible
       playSound: false,
       enableVibration: false,
     );
@@ -537,8 +537,8 @@ Do not force close this app.
       _channelId,
       _channelName,
       channelDescription: 'Real-time beat plan tracking - Keep this active',
-      importance: Importance.high, // Changed to high for visibility
-      priority: Priority.high, // Changed to high
+      importance: Importance.max, // MAX importance for Uber-like non-dismissible notification
+      priority: Priority.high, // High priority
       ongoing: true, // Cannot be dismissed by user
       autoCancel: false,
       playSound: false,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -88,12 +88,12 @@ Future<void> main() async {
 
     await notificationPlugin.initialize(initializationSettings);
 
-    // Create notification channel for tracking (high importance like Uber)
+    // Create notification channel for tracking (MAX importance like Uber - non-dismissible)
     const AndroidNotificationChannel channel = AndroidNotificationChannel(
       'tracking_channel',
       'Beat Plan Tracking',
       description: 'Real-time beat plan tracking - Keep this notification active',
-      importance: Importance.high, // High importance for visibility
+      importance: Importance.max, // MAX importance - truly non-dismissible
       playSound: false,
       enableVibration: false,
       showBadge: true,


### PR DESCRIPTION
This pull request strengthens the persistence and visibility of location tracking and socket services, particularly focusing on preventing their disposal during navigation and ensuring that tracking notifications are highly visible and non-dismissible (similar to the Uber app). The changes mainly update provider annotations for service lifecycles and increase notification importance for ongoing tracking.

**Provider lifecycle improvements:**

* Updated the `@riverpod` annotation to `@Riverpod(keepAlive: true)` for both `locationTrackingService` in `location_tracking_provider.dart` and `trackingSocketService` in `tracking_socket_provider.dart` to prevent these singleton services from being disposed during navigation; disposal now only occurs on explicit logout or app shutdown. [[1]](diffhunk://#diff-c0686a16dcd8e72350f73b70e346296f4b858a2dcd3ffb2042b11f8a5430d6b9L9-R18) [[2]](diffhunk://#diff-a530ca4fd0537ce202842905dd5727f14efcf30ef6f09a722f3eab73a60c50adL9-R18)

**Notification channel enhancements:**

* Raised the Android notification channel importance to `Importance.max` (from `low` or `high`) in `BackgroundTrackingService` and in the main app initialization, making tracking notifications truly non-dismissible and always visible, emulating Uber-like behavior. [[1]](diffhunk://#diff-e8e0a25e05bb15ea9b83b140b28f10655825bdd26dba3544330f8a46002767bbL479-R484) [[2]](diffhunk://#diff-e8e0a25e05bb15ea9b83b140b28f10655825bdd26dba3544330f8a46002767bbL540-R541) [[3]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L91-R96)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Location tracking and socket services now maintain state consistently across app navigation, preventing service interruption.
  * Android tracking notifications are now non-dismissible and display with maximum visibility for enhanced user awareness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->