### PR TITLE
refactor(utilities): refactored primary text field

### DIFF
--- a/lib/features/expense-claim/views/add_expense_claim_screen.dart
+++ b/lib/features/expense-claim/views/add_expense_claim_screen.dart
@@ -434,9 +434,11 @@ class _AddExpenseClaimScreenState extends ConsumerState<AddExpenseClaimScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      SizedBox(height: 8.h),
                       // 1. Title
                       PrimaryTextField(
-                        hintText: "Title",
+                        label: const Text("Title"),
+                        hintText: "Enter title",
                         controller: _titleController,
                         prefixIcon: Icons.title_outlined,
                         hasFocusBorder: true,
@@ -449,7 +451,8 @@ class _AddExpenseClaimScreenState extends ConsumerState<AddExpenseClaimScreen> {
 
                       // 2. Amount
                       PrimaryTextField(
-                        hintText: "Amount",
+                        label: const Text("Amount"),
+                        hintText: "Enter amount",
                         controller: _amountController,
                         prefixIcon: Icons.currency_rupee,
                         hasFocusBorder: true,
@@ -731,7 +734,8 @@ class _AddExpenseClaimScreenState extends ConsumerState<AddExpenseClaimScreen> {
 
                       // 6. Description
                       PrimaryTextField(
-                        hintText: "Description",
+                        label: const Text("Description"),
+                        hintText: "Enter description (optional)",
                         controller: _descriptionController,
                         prefixIcon: Icons.description_outlined,
                         hasFocusBorder: true,

--- a/lib/features/expense-claim/views/edit_expense_claim_screen.dart
+++ b/lib/features/expense-claim/views/edit_expense_claim_screen.dart
@@ -681,9 +681,11 @@ class _EditExpenseClaimScreenState
                             ),
                             child: Column(
                               children: [
+                                SizedBox(height: 8.h),
                                 // Title
                                 PrimaryTextField(
-                                  hintText: "Title",
+                                  label: const Text("Title"),
+                                  hintText: "Enter title",
                                   controller: _titleController,
                                   prefixIcon: Icons.title_outlined,
                                   hasFocusBorder: true,
@@ -697,7 +699,8 @@ class _EditExpenseClaimScreenState
 
                                 // Amount
                                 PrimaryTextField(
-                                  hintText: "Amount (INR)",
+                                  label: const Text("Amount"),
+                                  hintText: "Enter amount",
                                   controller: _amountController,
                                   prefixIcon: Icons.currency_rupee,
                                   hasFocusBorder: true,
@@ -885,7 +888,8 @@ class _EditExpenseClaimScreenState
 
                                 // Description
                                 PrimaryTextField(
-                                  hintText: "Description (Optional)",
+                                  label: const Text("Description"),
+                                  hintText: "Enter description (optional)",
                                   controller: _descriptionController,
                                   prefixIcon: Icons.description_outlined,
                                   hasFocusBorder: true,

--- a/lib/features/leave/views/apply_leave_screen.dart
+++ b/lib/features/leave/views/apply_leave_screen.dart
@@ -135,6 +135,7 @@ class _ApplyLeaveRequestScreenState
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
+                        SizedBox(height: 8.h),
                         CustomDatePicker(
                           controller: _startDateController,
                           hintText: "Start Date",
@@ -201,7 +202,8 @@ class _ApplyLeaveRequestScreenState
 
                         PrimaryTextField(
                           controller: _reasonController,
-                          hintText: "Reason",
+                          label: const Text("Reason"),
+                          hintText: "Enter reason for leave",
                           prefixIcon: Icons.description_outlined,
                           hasFocusBorder: true,
                           minLines: 1,

--- a/lib/features/leave/views/edit_leave_screen.dart
+++ b/lib/features/leave/views/edit_leave_screen.dart
@@ -363,6 +363,7 @@ class _EditLeaveScreenState extends ConsumerState<EditLeaveScreen> {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
+                            SizedBox(height: 8.h),
                       CustomDatePicker(
                         controller: _startDateController,
                         hintText: "Start Date",
@@ -430,7 +431,8 @@ class _EditLeaveScreenState extends ConsumerState<EditLeaveScreen> {
 
                       PrimaryTextField(
                         controller: _reasonController,
-                        hintText: "Reason",
+                        label: const Text("Reason"),
+                        hintText: "Enter reason for leave",
                         prefixIcon: Icons.description_outlined,
                         hasFocusBorder: true,
                         enabled: _isEditMode,

--- a/lib/features/miscellaneous/views/add_miscellaneous_work_screen.dart
+++ b/lib/features/miscellaneous/views/add_miscellaneous_work_screen.dart
@@ -305,9 +305,11 @@ class _AddMiscellaneousWorkScreenState
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      SizedBox(height: 8.h),
                       // Nature of Work
                       PrimaryTextField(
-                        hintText: "Nature of Work",
+                        label: const Text("Nature of Work"),
+                        hintText: "Enter nature of work",
                         controller: _natureOfWorkController,
                         prefixIcon: Icons.work_outline,
                         hasFocusBorder: true,
@@ -322,7 +324,8 @@ class _AddMiscellaneousWorkScreenState
 
                       // Assigned By
                       PrimaryTextField(
-                        hintText: "Assigned By",
+                        label: const Text("Assigned By"),
+                        hintText: "Enter assigned by",
                         controller: _assignedByController,
                         prefixIcon: Icons.person_outline,
                         hasFocusBorder: true,
@@ -392,7 +395,8 @@ class _AddMiscellaneousWorkScreenState
 
                       // Latitude (Non-editable)
                       PrimaryTextField(
-                        hintText: "Latitude (Auto-generated)",
+                        label: const Text("Latitude"),
+                        hintText: "Auto-generated from map",
                         controller: _latitudeController,
                         prefixIcon: Icons.explore_outlined,
                         hasFocusBorder: true,
@@ -402,7 +406,8 @@ class _AddMiscellaneousWorkScreenState
 
                       // Longitude (Non-editable)
                       PrimaryTextField(
-                        hintText: "Longitude (Auto-generated)",
+                        label: const Text("Longitude"),
+                        hintText: "Auto-generated from map",
                         controller: _longitudeController,
                         prefixIcon: Icons.explore_outlined,
                         hasFocusBorder: true,
@@ -444,6 +449,7 @@ class _AddMiscellaneousWorkScreenState
             ),
             color: Colors.white,
             child: PrimaryButton(
+
               label: 'Submit',
               onPressed: _handleSubmit,
               size: ButtonSize.medium,

--- a/lib/features/miscellaneous/views/edit_miscellaneous_work_screen.dart
+++ b/lib/features/miscellaneous/views/edit_miscellaneous_work_screen.dart
@@ -444,9 +444,11 @@ class _EditMiscellaneousWorkScreenState
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
+                            SizedBox(height: 8.h),
                       // Nature of Work
                       PrimaryTextField(
-                        hintText: "Nature of Work",
+                        label: const Text("Nature of Work"),
+                        hintText: "Enter nature of work",
                         controller: _natureOfWorkController,
                         prefixIcon: Icons.work_outline,
                         hasFocusBorder: true,
@@ -462,7 +464,8 @@ class _EditMiscellaneousWorkScreenState
 
                       // Assigned By
                       PrimaryTextField(
-                        hintText: "Assigned By",
+                        label: const Text("Assigned By"),
+                        hintText: "Enter assigned by",
                         controller: _assignedByController,
                         prefixIcon: Icons.person_outline,
                         hasFocusBorder: true,
@@ -537,7 +540,8 @@ class _EditMiscellaneousWorkScreenState
 
                       // Latitude (Non-editable)
                       PrimaryTextField(
-                        hintText: "Latitude (Auto-generated)",
+                        label: const Text("Latitude"),
+                        hintText: "Auto-generated from map",
                         controller: _latitudeController,
                         prefixIcon: Icons.explore_outlined,
                         hasFocusBorder: true,
@@ -547,7 +551,8 @@ class _EditMiscellaneousWorkScreenState
 
                       // Longitude (Non-editable)
                       PrimaryTextField(
-                        hintText: "Longitude (Auto-generated)",
+                        label: const Text("Longitude"),
+                        hintText: "Auto-generated from map",
                         controller: _longitudeController,
                         prefixIcon: Icons.explore_outlined,
                         hasFocusBorder: true,

--- a/lib/features/notes/views/add_notes_screen.dart
+++ b/lib/features/notes/views/add_notes_screen.dart
@@ -197,6 +197,9 @@ class _AddNotesScreenState extends ConsumerState<AddNotesScreen> {
             noteId,
             _selectedImages.map((e) => File(e.path)).toList(),
           );
+        } else {
+          // No images to upload, release the provider manually
+          vm.release();
         }
 
         if (mounted) {
@@ -500,9 +503,11 @@ class _AddNotesScreenState extends ConsumerState<AddNotesScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      SizedBox(height: 8.h),
                       PrimaryTextField(
                         controller: _titleController,
-                        hintText: "Title",
+                        label: const Text("Title"),
+                        hintText: "Enter title",
                         prefixIcon: Icons.description_outlined,
                         hasFocusBorder: true,
                         enabled: !_isSubmitting,
@@ -535,7 +540,8 @@ class _AddNotesScreenState extends ConsumerState<AddNotesScreen> {
                       SizedBox(height: 20.h),
 
                       PrimaryTextField(
-                        hintText: "Description",
+                        label: const Text("Description"),
+                        hintText: "Enter description",
                         controller: _descriptionController,
                         prefixIcon: Icons.description_outlined,
                         hasFocusBorder: true,

--- a/lib/features/notes/views/edit_notes_screen.dart
+++ b/lib/features/notes/views/edit_notes_screen.dart
@@ -183,7 +183,13 @@ class _EditNoteScreenState extends ConsumerState<EditNoteScreen> {
 
           if (imagesToUpload.isNotEmpty) {
             await vm.uploadNoteImages(widget.noteId, imagesToUpload);
+          } else {
+            // No new images to upload, release the provider
+            vm.release();
           }
+        } else {
+          // No new images at all, release the provider
+          vm.release();
         }
 
         if (mounted) {
@@ -582,9 +588,11 @@ class _EditNoteScreenState extends ConsumerState<EditNoteScreen> {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
+                                SizedBox(height: 8.h),
                                 PrimaryTextField(
                                   controller: _titleController,
-                                  hintText: "Title",
+                                  label: const Text("Title"),
+                                  hintText: "Enter title",
                                   prefixIcon: Icons.title,
                                   enabled: _isEditMode && !_isSubmitting,
                                   validator: (v) =>
@@ -615,7 +623,8 @@ class _EditNoteScreenState extends ConsumerState<EditNoteScreen> {
                                 SizedBox(height: 16.h),
                                 PrimaryTextField(
                                   controller: _descriptionController,
-                                  hintText: "Description",
+                                  label: const Text("Description"),
+                                  hintText: "Enter description",
                                   prefixIcon: Icons.description_outlined,
                                   enabled: _isEditMode && !_isSubmitting,
                                   minLines: 1,

--- a/lib/features/notes/vm/add_notes.vm.dart
+++ b/lib/features/notes/vm/add_notes.vm.dart
@@ -9,10 +9,39 @@ import 'package:sales_sphere/features/notes/models/notes.model.dart';
 
 part 'add_notes.vm.g.dart';
 
+/// Notes Add ViewModel
+/// Uses ref.keepAlive() to prevent premature disposal during async operations
 @riverpod
 class AddNoteViewModel extends _$AddNoteViewModel {
+  Object? _link;
+
   @override
-  FutureOr<void> build() => null;
+  void build() {
+    ref.onDispose(() {
+      if (_link != null) {
+        (_link as dynamic).close();
+      }
+      AppLogger.d('🧹 AddNoteViewModel disposed');
+    });
+  }
+
+  /// Keep provider alive for multi-step operations
+  void _keepAlive() {
+    _link ??= ref.keepAlive();
+  }
+
+  /// Release the keep alive after operations complete
+  void _release() {
+    if (_link != null) {
+      (_link as dynamic).close();
+      _link = null;
+    }
+  }
+
+  /// Public method to manually release the provider (call when no images to upload)
+  void release() {
+    _release();
+  }
 
   Future<String> createNote({
     required String title,
@@ -21,6 +50,8 @@ class AddNoteViewModel extends _$AddNoteViewModel {
     String? prospectId,
     String? siteId,
   }) async {
+    // Keep provider alive for subsequent image uploads
+    _keepAlive();
     state = const AsyncLoading();
 
     try {
@@ -44,13 +75,16 @@ class AddNoteViewModel extends _$AddNoteViewModel {
       if (apiResponse.success) {
         AppLogger.i('Note created successfully: ${apiResponse.data.id}');
         state = const AsyncData(null);
+        // Don't release yet - images might be uploaded next
         return apiResponse.data.id;
       } else {
+        _release();
         state = AsyncError(apiResponse.message, StackTrace.current);
         throw Exception(apiResponse.message);
       }
     } on DioException catch (e, stack) {
       AppLogger.e('Failed to create note', e, stack);
+      _release();
 
       String errorMessage = 'Failed to create note';
       if (e.error is NetworkException) {
@@ -62,20 +96,24 @@ class AddNoteViewModel extends _$AddNoteViewModel {
       throw Exception(errorMessage);
     } catch (e, stack) {
       AppLogger.e('Unexpected error creating note', e, stack);
+      _release();
       state = AsyncError(e.toString(), stack);
       rethrow;
     }
   }
 
   Future<void> uploadNoteImages(String noteId, List<File> images) async {
-    if (images.isEmpty) return;
+    if (images.isEmpty) {
+      _release();
+      return;
+    }
 
     try {
       final dio = ref.read(dioClientProvider);
 
       for (int i = 0; i < images.length; i++) {
         final file = images[i];
-        final imageNumber = i + 1; // 1-based index
+        final imageNumber = i + 1;
 
         final formData = FormData.fromMap({
           'imageNumber': imageNumber,
@@ -92,12 +130,20 @@ class AddNoteViewModel extends _$AddNoteViewModel {
 
         AppLogger.i('Uploaded image $imageNumber/${images.length} for note $noteId');
       }
+
+      // Release after all images uploaded
+      _release();
     } on DioException catch (e) {
       AppLogger.e('Failed to upload note images', e);
+      _release();
       if (e.error is NetworkException) {
         throw Exception((e.error as NetworkException).userFriendlyMessage);
       }
       throw Exception('Failed to upload images');
+    } catch (e) {
+      AppLogger.e('Unexpected error uploading images', e);
+      _release();
+      rethrow;
     }
   }
 }

--- a/lib/features/notes/vm/edit_notes.vm.dart
+++ b/lib/features/notes/vm/edit_notes.vm.dart
@@ -9,13 +9,44 @@ import 'package:sales_sphere/features/notes/models/notes.model.dart';
 
 part 'edit_notes.vm.g.dart';
 
+/// Notes Edit ViewModel
+/// Uses ref.keepAlive() to prevent premature disposal during async operations
 @riverpod
 class EditNoteViewModel extends _$EditNoteViewModel {
+  Object? _link;
+
   @override
-  FutureOr<void> build() => null;
+  void build() {
+    ref.onDispose(() {
+      if (_link != null) {
+        (_link as dynamic).close();
+      }
+      AppLogger.d('🧹 EditNoteViewModel disposed');
+    });
+  }
+
+  /// Keep provider alive for multi-step operations
+  void _keepAlive() {
+    _link ??= ref.keepAlive();
+  }
+
+  /// Release the keep alive after operations complete
+  void _release() {
+    if (_link != null) {
+      (_link as dynamic).close();
+      _link = null;
+    }
+  }
+
+  /// Public method to manually release the provider
+  void release() {
+    _release();
+  }
 
   /// Fetch note details by ID
   Future<NoteApiData> fetchNoteDetails(String noteId) async {
+    _keepAlive();
+
     try {
       final dio = ref.read(dioClientProvider);
       final response = await dio.get(ApiEndpoints.noteById(noteId));
@@ -26,9 +57,11 @@ class EditNoteViewModel extends _$EditNoteViewModel {
         AppLogger.i('Fetched note details: ${apiResponse.data.id}');
         return apiResponse.data;
       } else {
+        _release();
         throw Exception('Failed to fetch note details');
       }
     } on DioException catch (e) {
+      _release();
       AppLogger.e('Failed to fetch note details', e);
       if (e.error is NetworkException) {
         throw Exception((e.error as NetworkException).userFriendlyMessage);
@@ -46,6 +79,7 @@ class EditNoteViewModel extends _$EditNoteViewModel {
     String? prospectId,
     String? siteId,
   }) async {
+    _keepAlive();
     state = const AsyncLoading();
 
     try {
@@ -68,19 +102,18 @@ class EditNoteViewModel extends _$EditNoteViewModel {
 
       if (apiResponse.success) {
         AppLogger.i('Note updated successfully: ${apiResponse.data.id}');
-        if (ref.mounted) {
-          state = const AsyncData(null);
-        }
+        state = const AsyncData(null);
+        // Don't release yet - images might be uploaded next
         return apiResponse.data;
       } else {
+        _release();
         final errorMsg = apiResponse.message ?? 'Failed to update note';
-        if (ref.mounted) {
-          state = AsyncError(errorMsg, StackTrace.current);
-        }
+        state = AsyncError(errorMsg, StackTrace.current);
         throw Exception(errorMsg);
       }
     } on DioException catch (e, stack) {
       AppLogger.e('Failed to update note', e, stack);
+      _release();
 
       String errorMessage = 'Failed to update note';
       if (e.error is NetworkException) {
@@ -88,22 +121,22 @@ class EditNoteViewModel extends _$EditNoteViewModel {
         errorMessage = error.userFriendlyMessage;
       }
 
-      if (ref.mounted) {
-        state = AsyncError(errorMessage, stack);
-      }
+      state = AsyncError(errorMessage, stack);
       throw Exception(errorMessage);
     } catch (e, stack) {
       AppLogger.e('Unexpected error updating note', e, stack);
-      if (ref.mounted) {
-        state = AsyncError(e.toString(), stack);
-      }
+      _release();
+      state = AsyncError(e.toString(), stack);
       rethrow;
     }
   }
 
   /// Upload images to note
   Future<void> uploadNoteImages(String noteId, Map<int, File> images) async {
-    if (images.isEmpty) return;
+    if (images.isEmpty) {
+      _release();
+      return;
+    }
 
     try {
       final dio = ref.read(dioClientProvider);
@@ -127,12 +160,20 @@ class EditNoteViewModel extends _$EditNoteViewModel {
 
         AppLogger.i('Uploaded image $imageNumber for note $noteId');
       }
+
+      // Release after all images uploaded
+      _release();
     } on DioException catch (e) {
       AppLogger.e('Failed to upload note images', e);
+      _release();
       if (e.error is NetworkException) {
         throw Exception((e.error as NetworkException).userFriendlyMessage);
       }
       throw Exception('Failed to upload images');
+    } catch (e) {
+      AppLogger.e('Unexpected error uploading images', e);
+      _release();
+      rethrow;
     }
   }
 

--- a/lib/features/tour_plan/views/add_tour_screen.dart
+++ b/lib/features/tour_plan/views/add_tour_screen.dart
@@ -171,8 +171,10 @@ class _AddTourPlanScreenState extends ConsumerState<AddTourPlanScreen> {
                 child: SingleChildScrollView(
                   child: Column(
                     children: [
+                      SizedBox(height: 8.h),
                       PrimaryTextField(
-                        hintText: "Place of visit",
+                        label: const Text("Place of Visit"),
+                        hintText: "Enter place of visit",
                         controller: _placeController,
                         prefixIcon: Icons.location_on_outlined,
                         validator: (v) => ref
@@ -197,7 +199,8 @@ class _AddTourPlanScreenState extends ConsumerState<AddTourPlanScreen> {
                       ),
                       SizedBox(height: 16.h),
                       PrimaryTextField(
-                        hintText: "Purpose of the visit",
+                        label: const Text("Purpose of Visit"),
+                        hintText: "Enter purpose of the visit",
                         controller: _purposeController,
                         prefixIcon: Icons.description_outlined,
                         hasFocusBorder: true,

--- a/lib/features/tour_plan/views/edit_tour_details_screen.dart
+++ b/lib/features/tour_plan/views/edit_tour_details_screen.dart
@@ -290,8 +290,10 @@ class _EditTourDetailsScreenState extends ConsumerState<EditTourDetailsScreen> {
                       ),
                       child: Column(
                         children: [
+                          SizedBox(height: 8.h),
                           PrimaryTextField(
-                            hintText: "Place of visit",
+                            label: const Text("Place of Visit"),
+                            hintText: "Enter place of visit",
                             controller: _placeController,
                             prefixIcon: Icons.location_on_outlined,
                             enabled: isEditable,
@@ -320,7 +322,8 @@ class _EditTourDetailsScreenState extends ConsumerState<EditTourDetailsScreen> {
                           ),
                           SizedBox(height: 16.h),
                           PrimaryTextField(
-                            hintText: "Purpose of the visit",
+                            label: const Text("Purpose of Visit"),
+                            hintText: "Enter purpose of the visit",
                             controller: _purposeController,
                             prefixIcon: Icons.description_outlined,
                             enabled: isEditable,


### PR DESCRIPTION
This pull request focuses on improving the user experience and maintainability of several form-based screens across the application. The main changes include standardizing the appearance and labeling of text fields, enhancing spacing for better readability, and improving resource management in the notes feature to prevent premature disposal of providers during asynchronous operations.

**UI/UX Improvements:**

* Standardized all `PrimaryTextField` widgets across expense claim, leave, miscellaneous work, and notes screens to include explicit `label` properties and more descriptive `hintText` values, making forms clearer and more user-friendly. [[1]](diffhunk://#diff-307f274db4d97ef5cdd8450d35a274a12a7a3f478e3b1953735a6fce0d30f50eR437-R441) [[2]](diffhunk://#diff-307f274db4d97ef5cdd8450d35a274a12a7a3f478e3b1953735a6fce0d30f50eL452-R455) [[3]](diffhunk://#diff-307f274db4d97ef5cdd8450d35a274a12a7a3f478e3b1953735a6fce0d30f50eL734-R738) [[4]](diffhunk://#diff-45b7bcc56d68a46696c7a1919b9c11f2fee5318bf5c531df001e420ef2cc8645R684-R688) [[5]](diffhunk://#diff-45b7bcc56d68a46696c7a1919b9c11f2fee5318bf5c531df001e420ef2cc8645L700-R703) [[6]](diffhunk://#diff-45b7bcc56d68a46696c7a1919b9c11f2fee5318bf5c531df001e420ef2cc8645L888-R892) [[7]](diffhunk://#diff-51245ed03e2ebb4c89448d80dbd34eeabf7a2ff31169ca1f0a39b49a6b60d4b4L204-R206) [[8]](diffhunk://#diff-bdd806da401bdf8261f2f89318716629dd50acb4e157b6d754758097e35492f1L433-R435) [[9]](diffhunk://#diff-fa34c79e362de141072c8030e7d3cdb10fc55ee715f65f488d8fc59f5b7ae28eR308-R312) [[10]](diffhunk://#diff-fa34c79e362de141072c8030e7d3cdb10fc55ee715f65f488d8fc59f5b7ae28eL325-R328) [[11]](diffhunk://#diff-fa34c79e362de141072c8030e7d3cdb10fc55ee715f65f488d8fc59f5b7ae28eL395-R399) [[12]](diffhunk://#diff-fa34c79e362de141072c8030e7d3cdb10fc55ee715f65f488d8fc59f5b7ae28eL405-R410) [[13]](diffhunk://#diff-d0282d978af03687ab33d8e3f27f638d4d37d09e2438e72d3ae9cd7950724ba4R447-R451) [[14]](diffhunk://#diff-d0282d978af03687ab33d8e3f27f638d4d37d09e2438e72d3ae9cd7950724ba4L465-R468) [[15]](diffhunk://#diff-d0282d978af03687ab33d8e3f27f638d4d37d09e2438e72d3ae9cd7950724ba4L540-R544) [[16]](diffhunk://#diff-d0282d978af03687ab33d8e3f27f638d4d37d09e2438e72d3ae9cd7950724ba4L550-R555) [[17]](diffhunk://#diff-b5b7c7ea6d1c240ca1d842a724e0dfcf96e9a495dbfd8acae2440263098e0522R506-R510) [[18]](diffhunk://#diff-b5b7c7ea6d1c240ca1d842a724e0dfcf96e9a495dbfd8acae2440263098e0522L538-R544) [[19]](diffhunk://#diff-3a5adf973ecd746b1405720ef31c35260e8b3a6cb3ea3e4e899d79f258f29b54R591-R595) [[20]](diffhunk://#diff-3a5adf973ecd746b1405720ef31c35260e8b3a6cb3ea3e4e899d79f258f29b54L618-R627)
* Added consistent vertical spacing (`SizedBox(height: 8.h)`) at the top of form sections to improve layout aesthetics and readability. [[1]](diffhunk://#diff-307f274db4d97ef5cdd8450d35a274a12a7a3f478e3b1953735a6fce0d30f50eR437-R441) [[2]](diffhunk://#diff-45b7bcc56d68a46696c7a1919b9c11f2fee5318bf5c531df001e420ef2cc8645R684-R688) [[3]](diffhunk://#diff-51245ed03e2ebb4c89448d80dbd34eeabf7a2ff31169ca1f0a39b49a6b60d4b4R138) [[4]](diffhunk://#diff-bdd806da401bdf8261f2f89318716629dd50acb4e157b6d754758097e35492f1R366) [[5]](diffhunk://#diff-fa34c79e362de141072c8030e7d3cdb10fc55ee715f65f488d8fc59f5b7ae28eR308-R312) [[6]](diffhunk://#diff-d0282d978af03687ab33d8e3f27f638d4d37d09e2438e72d3ae9cd7950724ba4R447-R451) [[7]](diffhunk://#diff-b5b7c7ea6d1c240ca1d842a724e0dfcf96e9a495dbfd8acae2440263098e0522R506-R510) [[8]](diffhunk://#diff-3a5adf973ecd746b1405720ef31c35260e8b3a6cb3ea3e4e899d79f258f29b54R591-R595)

**Resource Management and Provider Lifecycle (Notes Feature):**

* Enhanced the `AddNoteViewModel` in `add_notes.vm.dart` to use `ref.keepAlive()` for preventing premature disposal during multi-step async operations (such as note creation followed by image upload). Added explicit `release()` methods to manually release the provider when no further async work is required. [[1]](diffhunk://#diff-ffd1d49fab4aefd051a4adc8dc5e7a61fa02bcc5e35952599c77ca5b9ae0ff27R12-R44) [[2]](diffhunk://#diff-ffd1d49fab4aefd051a4adc8dc5e7a61fa02bcc5e35952599c77ca5b9ae0ff27R53-R54) [[3]](diffhunk://#diff-ffd1d49fab4aefd051a4adc8dc5e7a61fa02bcc5e35952599c77ca5b9ae0ff27R78-R87)
* Updated add and edit notes screens to call `vm.release()` when there are no images to upload, ensuring proper cleanup and avoiding resource leaks. [[1]](diffhunk://#diff-b5b7c7ea6d1c240ca1d842a724e0dfcf96e9a495dbfd8acae2440263098e0522R200-R202) [[2]](diffhunk://#diff-3a5adf973ecd746b1405720ef31c35260e8b3a6cb3ea3e4e899d79f258f29b54R186-R192)

**Other Minor Improvements:**

* Improved button layout in the miscellaneous work add screen for better visual consistency.

These changes collectively enhance the clarity, consistency, and maintainability of the form UIs and improve the robustness of asynchronous operations in the notes feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Link to" functionality in notes, allowing you to associate notes with specific entities.

* **Improvements**
  * Enhanced form layouts across expense claims, leave requests, miscellaneous work, notes, and tour plans with clearer field labels and more descriptive placeholder text.
  * Added improved spacing between form fields for better visual organization.
  * Updated image upload section with optional labeling and clearer messaging.
  * Strengthened form validation for required fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->