### PR TITLE
enhancmenet: fix prospect and sites interest

### DIFF
--- a/lib/features/parties/views/add_party_screen.dart
+++ b/lib/features/parties/views/add_party_screen.dart
@@ -19,10 +19,12 @@ import 'package:sales_sphere/widget/custom_button.dart';
 import 'package:sales_sphere/widget/custom_date_picker.dart';
 import 'package:sales_sphere/widget/custom_text_field.dart';
 import 'package:sales_sphere/widget/location_picker_widget.dart';
-import 'package:sales_sphere/widget/primary_async_dropdown.dart';
 import 'package:sales_sphere/widget/primary_image_picker.dart';
 
 import '../../../core/utils/logger.dart';
+
+// Constant for "Add New..." option in party type dropdown
+const String _kAddNewPartyType = '__add_new_party_type__';
 
 // Google Places service provider
 final googlePlacesServiceProvider = Provider<GooglePlacesService>((ref) {
@@ -56,9 +58,13 @@ class _AddPartyScreenState extends ConsumerState<AddPartyScreen> {
   late TextEditingController _dateJoinedController;
   late TextEditingController _latitudeController;
   late TextEditingController _longitudeController;
+  late TextEditingController _newPartyTypeController;
 
   // Party type selection
   String? _selectedPartyType;
+
+  // Whether to show the "Add New Party Type" text field
+  bool _showNewPartyTypeField = false;
 
   // Image selection
   XFile? _selectedImage;
@@ -88,6 +94,7 @@ class _AddPartyScreenState extends ConsumerState<AddPartyScreen> {
     _dateJoinedController = TextEditingController();
     _latitudeController = TextEditingController();
     _longitudeController = TextEditingController();
+    _newPartyTypeController = TextEditingController();
   }
 
   @override
@@ -102,6 +109,7 @@ class _AddPartyScreenState extends ConsumerState<AddPartyScreen> {
     _dateJoinedController.dispose();
     _latitudeController.dispose();
     _longitudeController.dispose();
+    _newPartyTypeController.dispose();
     super.dispose();
   }
 
@@ -233,6 +241,13 @@ class _AddPartyScreenState extends ConsumerState<AddPartyScreen> {
         }
 
         // Create request object
+        // Use new party type from text field if "Add New" was selected
+        final partyTypeToSend = _selectedPartyType == _kAddNewPartyType
+            ? (_newPartyTypeController.text.trim().isEmpty
+                    ? null
+                    : _newPartyTypeController.text.trim())
+            : _selectedPartyType;
+
         final createRequest = CreatePartyRequest(
           partyName: _nameController.text.trim(),
           ownerName: _ownerNameController.text.trim(),
@@ -240,7 +255,7 @@ class _AddPartyScreenState extends ConsumerState<AddPartyScreen> {
               ? DateFormat('yyyy-MM-dd').format(DateTime.now())
               : _dateJoinedController.text.trim(),
           panVatNumber: _panVatController.text.trim(),
-          partyType: _selectedPartyType,
+          partyType: partyTypeToSend,
           contact: CreatePartyContact(
             phone: _phoneController.text.trim(),
             email: _emailController.text.trim().isEmpty
@@ -580,17 +595,40 @@ class _AddPartyScreenState extends ConsumerState<AddPartyScreen> {
                       SizedBox(height: 16.h),
 
                       // Party Type Dropdown
-                      PrimaryAsyncDropdown<PartyType>(
-                        itemsAsync: ref.watch(partyTypesViewModelProvider),
-                        initialValue: _selectedPartyType,
-                        onChanged: (val) =>
-                            setState(() => _selectedPartyType = val),
-                        itemLabel: (type) => type.name,
-                        hintText: 'Party Type',
-                        prefixIcon: Icons.category_outlined,
-                        title: 'Select Party Type',
+                      _PartyTypeDropdown(
+                        partyTypesAsync: ref.watch(partyTypesViewModelProvider),
+                        selectedType: _selectedPartyType,
+                        onTypeSelected: (type) {
+                          setState(() {
+                            _selectedPartyType = type;
+                            _showNewPartyTypeField = (type == _kAddNewPartyType);
+                          });
+                        },
                       ),
                       SizedBox(height: 16.h),
+
+                      // Show text field when "Add New..." is selected
+                      if (_showNewPartyTypeField)
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            PrimaryTextField(
+                              hintText: "Enter New Party Type",
+                              controller: _newPartyTypeController,
+                              prefixIcon: Icons.edit_outlined,
+                              hasFocusBorder: true,
+                              textInputAction: TextInputAction.next,
+                              validator: (value) {
+                                if (_showNewPartyTypeField &&
+                                    (value == null || value.trim().isEmpty)) {
+                                  return 'Please enter a party type';
+                                }
+                                return null;
+                              },
+                            ),
+                            SizedBox(height: 16.h),
+                          ],
+                        ),
 
                       PrimaryTextField(
                         hintText: "Notes",
@@ -707,6 +745,323 @@ class _AddPartyScreenState extends ConsumerState<AddPartyScreen> {
               size: ButtonSize.medium,
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+// Custom widget for Party Type Dropdown with "Add New..." option
+class _PartyTypeDropdown extends ConsumerWidget {
+  final AsyncValue<List<PartyType>> partyTypesAsync;
+  final String? selectedType;
+  final ValueChanged<String?> onTypeSelected;
+
+  const _PartyTypeDropdown({
+    required this.partyTypesAsync,
+    required this.selectedType,
+    required this.onTypeSelected,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return partyTypesAsync.when(
+      data: (partyTypes) {
+        // Add "Add New..." option at the beginning
+        final displayValue = selectedType == _kAddNewPartyType
+            ? 'Add New...'
+            : selectedType;
+
+        return InkWell(
+          onTap: () => _showPartyTypeBottomSheet(context, partyTypes),
+          child: Container(
+            padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 14.h),
+            decoration: BoxDecoration(
+              color: AppColors.surface,
+              borderRadius: BorderRadius.circular(12.r),
+              border: Border.all(color: AppColors.border, width: 1.5),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  selectedType == _kAddNewPartyType
+                      ? Icons.add_circle_outline
+                      : Icons.category_outlined,
+                  color: AppColors.textSecondary,
+                  size: 20.sp,
+                ),
+                SizedBox(width: 12.w),
+                Expanded(
+                  child: Text(
+                    displayValue ?? 'Party Type (Optional)',
+                    style: TextStyle(
+                      fontSize: 15.sp,
+                      fontFamily: 'Poppins',
+                      fontWeight: FontWeight.w400,
+                      color: selectedType != null
+                          ? AppColors.textPrimary
+                          : AppColors.textHint,
+                    ),
+                  ),
+                ),
+                Icon(
+                  Icons.keyboard_arrow_down_rounded,
+                  color: AppColors.textSecondary,
+                  size: 20.sp,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+      loading: () => Container(
+        height: 48.h,
+        padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 14.h),
+        decoration: BoxDecoration(
+          color: AppColors.surface,
+          borderRadius: BorderRadius.circular(12.r),
+          border: Border.all(color: AppColors.border, width: 1.5),
+        ),
+        child: Center(
+          child: SizedBox(
+            width: 16.w,
+            height: 16.h,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+      ),
+      error: (_, __) => Container(
+        padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 14.h),
+        decoration: BoxDecoration(
+          color: AppColors.error.withValues(alpha: 0.05),
+          borderRadius: BorderRadius.circular(12.r),
+          border: Border.all(color: AppColors.error, width: 1.5),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              Icons.error_outline,
+              color: AppColors.error,
+              size: 20.sp,
+            ),
+            SizedBox(width: 12.w),
+            Expanded(
+              child: Text(
+                'Failed to load party types',
+                style: TextStyle(
+                  fontSize: 14.sp,
+                  color: AppColors.error,
+                  fontFamily: 'Poppins',
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showPartyTypeBottomSheet(
+    BuildContext context,
+    List<PartyType> partyTypes,
+  ) async {
+    final selected = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => _PartyTypeBottomSheet(
+        partyTypes: partyTypes,
+        selectedType: selectedType,
+      ),
+    );
+
+    if (selected != null) {
+      onTypeSelected(selected.isEmpty ? null : selected);
+    }
+  }
+}
+
+class _PartyTypeBottomSheet extends StatelessWidget {
+  final List<PartyType> partyTypes;
+  final String? selectedType;
+
+  const _PartyTypeBottomSheet({
+    required this.partyTypes,
+    required this.selectedType,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(24.r),
+          topRight: Radius.circular(24.r),
+        ),
+      ),
+      padding: EdgeInsets.only(
+        top: 20.h,
+        left: 20.w,
+        right: 20.w,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 20.h,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Handle bar
+          Center(
+            child: Container(
+              width: 40.w,
+              height: 4.h,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade300,
+                borderRadius: BorderRadius.circular(2.r),
+              ),
+            ),
+          ),
+          SizedBox(height: 20.h),
+
+          // Header
+          Row(
+            children: [
+              Icon(
+                Icons.category_outlined,
+                color: AppColors.primary,
+                size: 24.sp,
+              ),
+              SizedBox(width: 12.w),
+              Text(
+                'Select Party Type',
+                style: TextStyle(
+                  fontSize: 18.sp,
+                  fontWeight: FontWeight.w600,
+                  fontFamily: 'Poppins',
+                  color: Colors.grey.shade800,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: 8.h),
+          Text(
+            'Choose an existing type or create a new one',
+            style: TextStyle(
+              fontSize: 12.sp,
+              color: Colors.grey.shade500,
+              fontFamily: 'Poppins',
+            ),
+          ),
+          SizedBox(height: 20.h),
+
+          // Clear selection option
+          if (selectedType != null && selectedType!.isNotEmpty)
+            ListTile(
+              contentPadding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 4.h),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8.r),
+              ),
+              leading: Icon(
+                Icons.clear,
+                color: Colors.red.shade400,
+                size: 20.sp,
+              ),
+              title: Text(
+                'Clear selection',
+                style: TextStyle(
+                  fontSize: 14.sp,
+                  fontFamily: 'Poppins',
+                  color: Colors.red.shade400,
+                ),
+              ),
+              onTap: () => Navigator.pop(context, ''),
+            ),
+
+          // "Add New..." option at the top
+          ListTile(
+            contentPadding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 4.h),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8.r),
+            ),
+            tileColor: selectedType == _kAddNewPartyType
+                ? AppColors.primary.withValues(alpha: 0.1)
+                : null,
+            leading: Icon(
+              selectedType == _kAddNewPartyType
+                  ? Icons.check_circle
+                  : Icons.add_circle_outline,
+              color: selectedType == _kAddNewPartyType
+                  ? AppColors.primary
+                  : AppColors.success,
+              size: 20.sp,
+            ),
+            title: Text(
+              'Add New...',
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontFamily: 'Poppins',
+                fontWeight: selectedType == _kAddNewPartyType
+                    ? FontWeight.w600
+                    : FontWeight.w400,
+                color: selectedType == _kAddNewPartyType
+                    ? AppColors.primary
+                    : AppColors.success,
+              ),
+            ),
+            onTap: () => Navigator.pop(context, _kAddNewPartyType),
+          ),
+
+          Divider(height: 16.h),
+
+          // List of existing party types
+          Text(
+            'Existing Types',
+            style: TextStyle(
+              fontSize: 12.sp,
+              fontWeight: FontWeight.w500,
+              color: Colors.grey.shade500,
+              fontFamily: 'Poppins',
+            ),
+          ),
+          SizedBox(height: 8.h),
+
+          ListView.builder(
+            shrinkWrap: true,
+            itemCount: partyTypes.length,
+            itemBuilder: (context, index) {
+              final type = partyTypes[index];
+              final isSelected = selectedType == type.name;
+
+              return ListTile(
+                contentPadding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 4.h),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8.r),
+                ),
+                tileColor: isSelected
+                    ? AppColors.primary.withValues(alpha: 0.1)
+                    : null,
+                leading: Icon(
+                  isSelected ? Icons.check_circle : Icons.radio_button_unchecked,
+                  color: isSelected ? AppColors.primary : Colors.grey.shade400,
+                  size: 20.sp,
+                ),
+                title: Text(
+                  type.name,
+                  style: TextStyle(
+                    fontSize: 14.sp,
+                    fontFamily: 'Poppins',
+                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+                    color: isSelected ? AppColors.primary : Colors.grey.shade800,
+                  ),
+                ),
+                onTap: () => Navigator.pop(context, type.name),
+              );
+            },
+          ),
+          SizedBox(height: 20.h),
         ],
       ),
     );

--- a/lib/features/parties/vm/party_types.vm.dart
+++ b/lib/features/parties/vm/party_types.vm.dart
@@ -22,11 +22,11 @@ class PartyTypesViewModel extends _$PartyTypesViewModel {
   Future<List<PartyType>> fetchPartyTypes() async {
     try {
       AppLogger.i('📋 Fetching party types');
-      
+
       final dio = ref.read(dioClientProvider);
-      
+
       final response = await dio.get(ApiEndpoints.partyTypes);
-      
+
       if (response.statusCode == 200) {
         final apiResponse = PartyTypesApiResponse.fromJson(response.data);
         AppLogger.i('✅ Fetched ${apiResponse.count} party types');

--- a/lib/features/sites/widgets/site_interest_selector.dart
+++ b/lib/features/sites/widgets/site_interest_selector.dart
@@ -1,16 +1,43 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:sales_sphere/core/constants/app_colors.dart';
 import 'package:sales_sphere/features/sites/models/sites.model.dart';
 import 'package:sales_sphere/features/sites/vm/site_options.vm.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uuid/uuid.dart';
 
 part 'site_interest_selector.g.dart';
 
+/// Data class to hold selected brands and technicians for a category
+@immutable
+class SiteSelectionData {
+  final Set<String> brands;
+  final Set<SiteTechnician> technicians;
+
+  const SiteSelectionData({
+    this.brands = const {},
+    this.technicians = const {},
+  });
+
+  SiteSelectionData copyWith({
+    Set<String>? brands,
+    Set<SiteTechnician>? technicians,
+  }) {
+    return SiteSelectionData(
+      brands: brands ?? this.brands,
+      technicians: technicians ?? this.technicians,
+    );
+  }
+
+  bool get isEmpty => brands.isEmpty && technicians.isEmpty;
+  bool get isNotEmpty => !isEmpty;
+}
+
 /// Site Interest Selector Widget
 /// Compact view with chips + bottom sheet for selection
-/// Matches the UI and behavior of ProspectInterestSelector
+/// Supports category/brand/technician selection with "Add New" functionality
 class SiteInterestSelector extends ConsumerStatefulWidget {
   /// Initially selected interests (for edit mode)
   final List<SiteInterest> initiallySelected;
@@ -34,55 +61,54 @@ class SiteInterestSelector extends ConsumerStatefulWidget {
 }
 
 class _SiteInterestSelectorState extends ConsumerState<SiteInterestSelector> {
-  // Track selected brands per category (categoryName -> Set of selected brands)
-  final Map<String, Set<String>> _selectedBrands = {};
+  // Track selected data per category (categoryName -> SiteSelectionData)
+  final Map<String, SiteSelectionData> _selectedData = {};
 
   @override
   void initState() {
     super.initState();
-    _initializeSelectedBrands();
+    _initializeSelectedData();
   }
 
   @override
   void didUpdateWidget(SiteInterestSelector oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.initiallySelected != widget.initiallySelected) {
-      _initializeSelectedBrands();
+      _initializeSelectedData();
     }
   }
 
-  void _initializeSelectedBrands() {
-    _selectedBrands.clear();
+  void _initializeSelectedData() {
+    _selectedData.clear();
     for (final interest in widget.initiallySelected) {
-      _selectedBrands[interest.category] = interest.brands.toSet();
+      _selectedData[interest.category] = SiteSelectionData(
+        brands: interest.brands.toSet(),
+        technicians: interest.technicians.toSet(),
+      );
     }
   }
 
   void _removeBrand(String categoryName, String brand) {
     setState(() {
-      if (_selectedBrands.containsKey(categoryName)) {
-        _selectedBrands[categoryName]!.remove(brand);
-        if (_selectedBrands[categoryName]!.isEmpty) {
-          _selectedBrands.remove(categoryName);
+      final current = _selectedData[categoryName];
+      if (current != null) {
+        final newBrands = Set<String>.from(current.brands)..remove(brand);
+        if (newBrands.isEmpty && current.technicians.isEmpty) {
+          _selectedData.remove(categoryName);
+        } else {
+          _selectedData[categoryName] = current.copyWith(brands: newBrands);
         }
       }
       _notifyChanges();
     });
   }
 
-  void _removeCategory(String categoryName) {
-    setState(() {
-      _selectedBrands.remove(categoryName);
-      _notifyChanges();
-    });
-  }
-
   void _notifyChanges() {
-    final interests = _selectedBrands.entries.map((entry) {
+    final interests = _selectedData.entries.map((entry) {
       return SiteInterest(
         category: entry.key,
-        brands: entry.value.toList(),
-        technicians: const [],
+        brands: entry.value.brands.toList(),
+        technicians: entry.value.technicians.toList(),
       );
     }).toList();
 
@@ -90,26 +116,27 @@ class _SiteInterestSelectorState extends ConsumerState<SiteInterestSelector> {
   }
 
   void _openSelectionBottomSheet() async {
-    final result = await showModalBottomSheet<Map<String, Set<String>>>(
+    final result = await showModalBottomSheet<Map<String, SiteSelectionData>>(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (context) => _SiteInterestBottomSheet(
-        initiallySelected: Map.from(_selectedBrands),
+        initiallySelected: Map.from(_selectedData),
       ),
     );
 
     if (result != null) {
       setState(() {
-        _selectedBrands.clear();
-        _selectedBrands.addAll(result);
+        _selectedData.clear();
+        _selectedData.addAll(result);
         _notifyChanges();
       });
     }
   }
 
   int _getTotalSelectionCount() {
-    return _selectedBrands.values.fold(0, (sum, brands) => sum + brands.length);
+    // Count only categories that have any selections
+    return _selectedData.values.where((data) => data.isNotEmpty).length;
   }
 
   @override
@@ -152,7 +179,7 @@ class _SiteInterestSelectorState extends ConsumerState<SiteInterestSelector> {
           child: Column(
             children: [
               // Selected chips or empty state
-              if (_selectedBrands.isEmpty)
+              if (_selectedData.isEmpty)
                 _buildEmptyState()
               else
                 _buildSelectedChips(),
@@ -168,10 +195,10 @@ class _SiteInterestSelectorState extends ConsumerState<SiteInterestSelector> {
                     width: double.infinity,
                     padding: EdgeInsets.symmetric(vertical: 10.h),
                     decoration: BoxDecoration(
-                      color: AppColors.primary.withOpacity(0.08),
+                      color: AppColors.primary.withValues(alpha: 0.08),
                       borderRadius: BorderRadius.circular(8.r),
                       border: Border.all(
-                        color: AppColors.primary.withOpacity(0.3),
+                        color: AppColors.primary.withValues(alpha: 0.3),
                         width: 1,
                       ),
                     ),
@@ -185,7 +212,7 @@ class _SiteInterestSelectorState extends ConsumerState<SiteInterestSelector> {
                         ),
                         SizedBox(width: 8.w),
                         Text(
-                          _selectedBrands.isEmpty
+                          _selectedData.isEmpty
                               ? 'Select Interests'
                               : 'Modify Selection',
                           style: TextStyle(
@@ -225,19 +252,23 @@ class _SiteInterestSelectorState extends ConsumerState<SiteInterestSelector> {
     return Wrap(
       spacing: 6.w,
       runSpacing: 6.h,
-      children: _selectedBrands.entries.expand((entry) {
+      children: _selectedData.entries.expand((entry) {
         final categoryName = entry.key;
-        final brands = entry.value;
+        final data = entry.value;
+        final chips = <Widget>[];
 
-        return brands.map((brand) {
-          return _BrandChip(
+        // Add only brand chips (technicians shown inside modify selection only)
+        for (final brand in data.brands) {
+          chips.add(_BrandChip(
             category: categoryName,
             brand: brand,
             onRemove: widget.enabled
                 ? () => _removeBrand(categoryName, brand)
                 : null,
-          );
-        });
+          ));
+        }
+
+        return chips;
       }).toList(),
     );
   }
@@ -263,9 +294,9 @@ class _BrandChip extends StatelessWidget {
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 8.w, vertical: 4.h),
       decoration: BoxDecoration(
-        color: AppColors.primary.withOpacity(0.08),
+        color: AppColors.primary.withValues(alpha: 0.08),
         borderRadius: BorderRadius.circular(6.r),
-        border: Border.all(color: AppColors.primary.withOpacity(0.25)),
+        border: Border.all(color: AppColors.primary.withValues(alpha: 0.25)),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -309,7 +340,7 @@ class _BrandChip extends StatelessWidget {
 // ============================================================================
 
 class _SiteInterestBottomSheet extends ConsumerStatefulWidget {
-  final Map<String, Set<String>> initiallySelected;
+  final Map<String, SiteSelectionData> initiallySelected;
 
   const _SiteInterestBottomSheet({required this.initiallySelected});
 
@@ -320,32 +351,149 @@ class _SiteInterestBottomSheet extends ConsumerStatefulWidget {
 
 class _SiteInterestBottomSheetState
     extends ConsumerState<_SiteInterestBottomSheet> {
-  late Map<String, Set<String>> _selectedBrands;
+  late Map<String, SiteSelectionData> _selectedData;
   final Set<String> _expandedCategories = {};
+
+  // Custom categories added by user ( categoryName => Set<brands> )
+  final Map<String, Set<String>> _customCategories = {};
+
+  // Custom brands added to ANY category ( categoryName => Set<brands> )
+  final Map<String, Set<String>> _customBrands = {};
+
+  // Custom technicians added to ANY category ( categoryName => Set<technicians> )
+  final Map<String, Set<SiteTechnician>> _customTechnicians = {};
 
   @override
   void initState() {
     super.initState();
-    _selectedBrands = Map.from(widget.initiallySelected);
+    _selectedData = Map.from(widget.initiallySelected);
     // Expand categories that have selections
-    _expandedCategories.addAll(_selectedBrands.keys);
+    _expandedCategories.addAll(_selectedData.keys);
+  }
+
+  void _showAddCategoryDialog() {
+    final controller = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) => _AddCategoryDialog(
+        controller: controller,
+        onSave: () {
+          final categoryName = controller.text.trim();
+          if (categoryName.isNotEmpty) {
+            setState(() {
+              _customCategories.putIfAbsent(categoryName, () => {});
+              _expandedCategories.add(categoryName);
+            });
+          }
+        },
+      ),
+    );
+  }
+
+  void _showAddBrandDialog(String categoryName) {
+    final controller = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) => _AddBrandDialog(
+        categoryName: categoryName,
+        controller: controller,
+        onSave: (brandName) {
+          final brand = brandName.trim();
+          if (brand.isNotEmpty) {
+            setState(() {
+              // Add to custom brands for this category
+              _customBrands.putIfAbsent(categoryName, () => {});
+              _customBrands[categoryName]!.add(brand);
+
+              // Also add to selected data so it's checked by default
+              final current = _selectedData[categoryName];
+              final newBrands = Set<String>.from(current?.brands ?? {})
+                ..add(brand);
+              _selectedData[categoryName] =
+                  (current ?? const SiteSelectionData()).copyWith(
+                brands: newBrands,
+              );
+            });
+          }
+        },
+      ),
+    );
+  }
+
+  void _showAddTechnicianDialog(String categoryName) {
+    final nameController = TextEditingController();
+    final phoneController = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) => _AddTechnicianDialog(
+        categoryName: categoryName,
+        nameController: nameController,
+        phoneController: phoneController,
+        onSave: (technician) {
+          setState(() {
+            // Add to custom technicians for this category
+            _customTechnicians.putIfAbsent(categoryName, () => {});
+            _customTechnicians[categoryName]!.add(technician);
+
+            // Also add to selected data so it's checked by default
+            final current = _selectedData[categoryName];
+            final newTechnicians =
+                Set<SiteTechnician>.from(current?.technicians ?? {})
+                  ..add(technician);
+            _selectedData[categoryName] =
+                (current ?? const SiteSelectionData()).copyWith(
+              technicians: newTechnicians,
+            );
+          });
+        },
+      ),
+    );
   }
 
   void _toggleBrand(String categoryName, String brand) {
     setState(() {
-      if (!_selectedBrands.containsKey(categoryName)) {
-        _selectedBrands[categoryName] = {};
-      }
+      final current = _selectedData[categoryName] ?? const SiteSelectionData();
+      final newBrands = Set<String>.from(current.brands);
 
-      if (_selectedBrands[categoryName]!.contains(brand)) {
-        _selectedBrands[categoryName]!.remove(brand);
-        if (_selectedBrands[categoryName]!.isEmpty) {
-          _selectedBrands.remove(categoryName);
+      if (newBrands.contains(brand)) {
+        newBrands.remove(brand);
+        if (newBrands.isEmpty && current.technicians.isEmpty) {
+          _selectedData.remove(categoryName);
           _expandedCategories.remove(categoryName);
+          return;
         }
       } else {
-        _selectedBrands[categoryName]!.add(brand);
+        newBrands.add(brand);
       }
+
+      _selectedData[categoryName] = current.copyWith(brands: newBrands);
+    });
+  }
+
+  void _toggleTechnician(String categoryName, SiteTechnician technician) {
+    setState(() {
+      final current = _selectedData[categoryName] ?? const SiteSelectionData();
+      final newTechnicians = Set<SiteTechnician>.from(current.technicians);
+
+      // Find existing technician by name and phone (ignoring _id)
+      final existingTech = newTechnicians.firstWhere(
+        (t) => t.name == technician.name && t.phone == technician.phone,
+        orElse: () => technician,
+      );
+
+      if (newTechnicians.contains(existingTech)) {
+        newTechnicians.remove(existingTech);
+        if (current.brands.isEmpty && newTechnicians.isEmpty) {
+          _selectedData.remove(categoryName);
+          _expandedCategories.remove(categoryName);
+          return;
+        }
+      } else {
+        newTechnicians.add(technician);
+      }
+
+      _selectedData[categoryName] =
+          current.copyWith(technicians: newTechnicians);
     });
   }
 
@@ -360,19 +508,30 @@ class _SiteInterestBottomSheetState
   }
 
   int _getSelectedCountForCategory(String categoryName) {
-    return _selectedBrands[categoryName]?.length ?? 0;
+    final data = _selectedData[categoryName];
+    if (data == null) return 0;
+    return data.brands.length + data.technicians.length;
   }
 
   bool _isBrandSelected(String categoryName, String brand) {
-    return _selectedBrands[categoryName]?.contains(brand) ?? false;
+    return _selectedData[categoryName]?.brands.contains(brand) ?? false;
+  }
+
+  bool _isTechnicianSelected(String categoryName, SiteTechnician technician) {
+    final selectedTechs = _selectedData[categoryName]?.technicians;
+    if (selectedTechs == null) return false;
+    // Compare by name and phone only, ignoring _id field which may differ
+    return selectedTechs.any((t) =>
+        t.name == technician.name && t.phone == technician.phone);
   }
 
   void _applySelection() {
-    Navigator.of(context).pop(_selectedBrands);
+    context.pop(_selectedData);
   }
 
   int _getTotalSelectionCount() {
-    return _selectedBrands.values.fold(0, (sum, brands) => sum + brands.length);
+    // Count only categories that have any selections
+    return _selectedData.values.where((data) => data.isNotEmpty).length;
   }
 
   @override
@@ -422,7 +581,7 @@ class _SiteInterestBottomSheetState
                       vertical: 4.h,
                     ),
                     decoration: BoxDecoration(
-                      color: AppColors.primary.withOpacity(0.1),
+                      color: AppColors.primary.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(12.r),
                     ),
                     child: Text(
@@ -442,7 +601,25 @@ class _SiteInterestBottomSheetState
           Expanded(
             child: categoriesAsync.when(
               data: (categories) {
-                if (categories.isEmpty) {
+                // Combine API categories with custom categories
+                final allCategories = [
+                  ...categories,
+                  // Add custom categories that aren't in API response
+                  ..._customCategories.keys
+                      .where((customName) =>
+                          categories.every((c) => c.name != customName))
+                      .map((customName) => SiteCategory(
+                            id: const Uuid().v4(),
+                            name: customName,
+                            brands: _customCategories[customName]?.toList() ?? [],
+                            technicians: [],
+                            organizationId: '',
+                            createdAt: DateTime.now(),
+                            updatedAt: DateTime.now(),
+                          )),
+                ];
+
+                if (allCategories.isEmpty) {
                   return Center(
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -467,10 +644,17 @@ class _SiteInterestBottomSheetState
 
                 return ListView.separated(
                   padding: EdgeInsets.symmetric(horizontal: 16.w),
-                  itemCount: categories.length,
+                  itemCount: allCategories.length + 1, // +1 for "Add New Category"
                   separatorBuilder: (_, __) => SizedBox(height: 8.h),
                   itemBuilder: (context, index) {
-                    final category = categories[index];
+                    // Add New Category button at the top
+                    if (index == 0) {
+                      return _buildAddNewCategoryCard();
+                    }
+
+                    // Adjust index for actual categories
+                    final categoryIndex = index - 1;
+                    final category = allCategories[categoryIndex];
                     final selectedCount = _getSelectedCountForCategory(
                       category.name,
                     );
@@ -553,21 +737,77 @@ class _SiteInterestBottomSheetState
     );
   }
 
+  Widget _buildAddNewCategoryCard() {
+    return InkWell(
+      onTap: _showAddCategoryDialog,
+      borderRadius: BorderRadius.circular(12.r),
+      child: Container(
+        padding: EdgeInsets.all(16.w),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: AppColors.primary.withValues(alpha: 0.5),
+            style: BorderStyle.solid,
+          ),
+          borderRadius: BorderRadius.circular(12.r),
+          color: AppColors.primary.withValues(alpha: 0.03),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.add_circle_outline,
+              color: AppColors.primary,
+              size: 20.sp,
+            ),
+            SizedBox(width: 8.w),
+            Text(
+              'Add New Category',
+              style: TextStyle(
+                fontSize: 14.sp,
+                fontWeight: FontWeight.w500,
+                color: AppColors.primary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildCategoryCard({
     required SiteCategory category,
     required bool isExpanded,
     required int selectedCount,
   }) {
+    // Check if this is a custom category
+    final isCustomCategory = _customCategories.containsKey(category.name);
+
+    // Get all brands: original category brands + custom added brands
+    final allBrands = {
+      ...category.brands,
+      if (_customBrands.containsKey(category.name)) ..._customBrands[category.name]!,
+    }.toList();
+
+    // Get all technicians: original category technicians + custom added technicians
+    final allTechnicians = {
+      ...category.technicians,
+      if (_customTechnicians.containsKey(category.name))
+        ..._customTechnicians[category.name]!,
+    }.toList();
+
+    // Total count for display
+    final totalItemsCount = allBrands.length + allTechnicians.length;
+
     return Container(
       decoration: BoxDecoration(
         border: Border.all(
           color: selectedCount > 0
-              ? AppColors.primary.withOpacity(0.5)
+              ? AppColors.primary.withValues(alpha: 0.5)
               : AppColors.greyLight,
         ),
         borderRadius: BorderRadius.circular(12.r),
         color: selectedCount > 0
-            ? AppColors.primary.withOpacity(0.03)
+            ? AppColors.primary.withValues(alpha: 0.03)
             : Colors.white,
       ),
       child: Theme(
@@ -606,21 +846,44 @@ class _SiteInterestBottomSheetState
               ),
             ),
           ),
-          title: Text(
-            category.name,
-            style: TextStyle(
-              fontSize: 15.sp,
-              fontWeight: FontWeight.w500,
-              color: AppColors.textPrimary,
-            ),
+          title: Row(
+            children: [
+              Text(
+                category.name,
+                style: TextStyle(
+                  fontSize: 15.sp,
+                  fontWeight: FontWeight.w500,
+                  color: AppColors.textPrimary,
+                ),
+              ),
+              if (isCustomCategory) ...[
+                SizedBox(width: 6.w),
+                Container(
+                  padding:
+                      EdgeInsets.symmetric(horizontal: 6.w, vertical: 2.h),
+                  decoration: BoxDecoration(
+                    color: AppColors.primary.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(4.r),
+                  ),
+                  child: Text(
+                    'Custom',
+                    style: TextStyle(
+                      fontSize: 10.sp,
+                      color: AppColors.primary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ],
           ),
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
                 selectedCount == 0
-                    ? '${category.brands.length} brands'
-                    : '$selectedCount of ${category.brands.length}',
+                    ? '$totalItemsCount items'
+                    : '$selectedCount of $totalItemsCount',
                 style: TextStyle(
                   fontSize: 12.sp,
                   color: AppColors.textSecondary,
@@ -635,31 +898,515 @@ class _SiteInterestBottomSheetState
             ],
           ),
           children: [
-            ...category.brands.map((brand) {
-              final isSelected = _isBrandSelected(category.name, brand);
-              return CheckboxListTile(
-                contentPadding: EdgeInsets.zero,
-                title: Text(
-                  brand,
+            // Brands section
+            if (allBrands.isNotEmpty) ...[
+              Padding(
+                padding: EdgeInsets.only(bottom: 8.h),
+                child: Text(
+                  'Brands',
                   style: TextStyle(
-                    fontSize: 14.sp,
-                    color: AppColors.textPrimary,
-                    fontWeight: isSelected
-                        ? FontWeight.w500
-                        : FontWeight.normal,
+                    fontSize: 13.sp,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.textSecondary,
                   ),
                 ),
-                value: isSelected,
-                onChanged: (_) => _toggleBrand(category.name, brand),
-                controlAffinity: ListTileControlAffinity.leading,
-                activeColor: AppColors.primary,
-                checkColor: Colors.white,
-                dense: true,
-              );
-            }).toList(),
+              ),
+              ...allBrands.map((brand) {
+                final isSelected = _isBrandSelected(category.name, brand);
+                return CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: Text(
+                    brand,
+                    style: TextStyle(
+                      fontSize: 14.sp,
+                      color: AppColors.textPrimary,
+                      fontWeight:
+                          isSelected ? FontWeight.w500 : FontWeight.normal,
+                    ),
+                  ),
+                  value: isSelected,
+                  onChanged: (_) => _toggleBrand(category.name, brand),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  activeColor: AppColors.primary,
+                  checkColor: Colors.white,
+                  dense: true,
+                );
+              }),
+              // Add Brand button
+              InkWell(
+                onTap: () => _showAddBrandDialog(category.name),
+                borderRadius: BorderRadius.circular(8.r),
+                child: Container(
+                  margin: EdgeInsets.only(top: 4.h),
+                  padding:
+                      EdgeInsets.symmetric(vertical: 8.h, horizontal: 12.w),
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: AppColors.primary.withValues(alpha: 0.3),
+                      style: BorderStyle.solid,
+                    ),
+                    borderRadius: BorderRadius.circular(8.r),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.add,
+                        color: AppColors.primary,
+                        size: 16.sp,
+                      ),
+                      SizedBox(width: 6.w),
+                      Text(
+                        'Add Brand',
+                        style: TextStyle(
+                          fontSize: 13.sp,
+                          fontWeight: FontWeight.w500,
+                          color: AppColors.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+
+            // Technicians section
+            if (allTechnicians.isNotEmpty || true) ...[
+              SizedBox(height: 12.h),
+              Padding(
+                padding: EdgeInsets.only(bottom: 8.h),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.engineering,
+                      size: 16.sp,
+                      color: AppColors.textSecondary,
+                    ),
+                    SizedBox(width: 4.w),
+                    Text(
+                      'Technicians',
+                      style: TextStyle(
+                        fontSize: 13.sp,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (allTechnicians.isEmpty)
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8.h),
+                  child: Text(
+                    'No technicians available',
+                    style: TextStyle(
+                      fontSize: 12.sp,
+                      color: AppColors.greyMedium,
+                    ),
+                  ),
+                )
+              else
+                ...allTechnicians.map((tech) {
+                  final isSelected =
+                      _isTechnicianSelected(category.name, tech);
+                  return CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(
+                      tech.name,
+                      style: TextStyle(
+                        fontSize: 14.sp,
+                        color: AppColors.textPrimary,
+                        fontWeight:
+                            isSelected ? FontWeight.w500 : FontWeight.normal,
+                      ),
+                    ),
+                    subtitle: Text(
+                      tech.phone,
+                      style: TextStyle(
+                        fontSize: 12.sp,
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                    value: isSelected,
+                    onChanged: (_) => _toggleTechnician(category.name, tech),
+                    controlAffinity: ListTileControlAffinity.leading,
+                    activeColor: AppColors.secondary,
+                    checkColor: Colors.white,
+                    dense: true,
+                  );
+                }),
+              // Add Technician button
+              InkWell(
+                onTap: () => _showAddTechnicianDialog(category.name),
+                borderRadius: BorderRadius.circular(8.r),
+                child: Container(
+                  margin: EdgeInsets.only(top: 4.h),
+                  padding:
+                      EdgeInsets.symmetric(vertical: 8.h, horizontal: 12.w),
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: (AppColors.secondary)
+                          .withValues(alpha: 0.3),
+                      style: BorderStyle.solid,
+                    ),
+                    borderRadius: BorderRadius.circular(8.r),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.person_add,
+                        color: AppColors.secondary,
+                        size: 16.sp,
+                      ),
+                      SizedBox(width: 6.w),
+                      Text(
+                        'Add Technician',
+                        style: TextStyle(
+                          fontSize: 13.sp,
+                          fontWeight: FontWeight.w500,
+                          color: AppColors.secondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
       ),
+    );
+  }
+}
+
+// ============================================================================
+// ADD CATEGORY DIALOG
+// ============================================================================
+
+class _AddCategoryDialog extends StatefulWidget {
+  final TextEditingController controller;
+  final VoidCallback onSave;
+
+  const _AddCategoryDialog({
+    required this.controller,
+    required this.onSave,
+  });
+
+  @override
+  State<_AddCategoryDialog> createState() => _AddCategoryDialogState();
+}
+
+class _AddCategoryDialogState extends State<_AddCategoryDialog> {
+  @override
+  void dispose() {
+    widget.controller.dispose();
+    super.dispose();
+  }
+
+  void _handleSave() {
+    if (widget.controller.text.trim().isNotEmpty) {
+      widget.onSave();
+      context.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        'Add New Category',
+        style: TextStyle(
+          fontSize: 18.sp,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: widget.controller,
+            autofocus: true,
+            textCapitalization: TextCapitalization.words,
+            decoration: InputDecoration(
+              labelText: 'Category Name',
+              hintText: 'e.g., Security Systems',
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8.r),
+              ),
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: 12.w,
+                vertical: 12.h,
+              ),
+            ),
+            onSubmitted: (_) => _handleSave(),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => context.pop(),
+          child: Text(
+            'Cancel',
+            style: TextStyle(
+              fontSize: 14.sp,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        ElevatedButton(
+          onPressed: _handleSave,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+          ),
+          child: Text(
+            'Add',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ============================================================================
+// ADD BRAND DIALOG
+// ============================================================================
+
+class _AddBrandDialog extends StatefulWidget {
+  final String categoryName;
+  final TextEditingController controller;
+  final Function(String) onSave;
+
+  const _AddBrandDialog({
+    required this.categoryName,
+    required this.controller,
+    required this.onSave,
+  });
+
+  @override
+  State<_AddBrandDialog> createState() => _AddBrandDialogState();
+}
+
+class _AddBrandDialogState extends State<_AddBrandDialog> {
+  @override
+  void dispose() {
+    widget.controller.dispose();
+    super.dispose();
+  }
+
+  void _handleSave() {
+    if (widget.controller.text.trim().isNotEmpty) {
+      widget.onSave(widget.controller.text.trim());
+      context.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        'Add Brand to ${widget.categoryName}',
+        style: TextStyle(
+          fontSize: 18.sp,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: widget.controller,
+            autofocus: true,
+            textCapitalization: TextCapitalization.words,
+            decoration: InputDecoration(
+              labelText: 'Brand Name',
+              hintText: 'e.g., Hikvision',
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8.r),
+              ),
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: 12.w,
+                vertical: 12.h,
+              ),
+            ),
+            onSubmitted: (_) => _handleSave(),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => context.pop(),
+          child: Text(
+            'Cancel',
+            style: TextStyle(
+              fontSize: 14.sp,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        ElevatedButton(
+          onPressed: _handleSave,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+          ),
+          child: Text(
+            'Add',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ============================================================================
+// ADD TECHNICIAN DIALOG
+// ============================================================================
+
+class _AddTechnicianDialog extends StatefulWidget {
+  final String categoryName;
+  final TextEditingController nameController;
+  final TextEditingController phoneController;
+  final Function(SiteTechnician) onSave;
+
+  const _AddTechnicianDialog({
+    required this.categoryName,
+    required this.nameController,
+    required this.phoneController,
+    required this.onSave,
+  });
+
+  @override
+  State<_AddTechnicianDialog> createState() => _AddTechnicianDialogState();
+}
+
+class _AddTechnicianDialogState extends State<_AddTechnicianDialog> {
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    widget.nameController.dispose();
+    widget.phoneController.dispose();
+    super.dispose();
+  }
+
+  void _handleSave() {
+    if (_formKey.currentState?.validate() ?? false) {
+      final technician = SiteTechnician(
+        name: widget.nameController.text.trim(),
+        phone: widget.phoneController.text.trim(),
+      );
+      widget.onSave(technician);
+      context.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        'Add Technician to ${widget.categoryName}',
+        style: TextStyle(
+          fontSize: 18.sp,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextFormField(
+              controller: widget.nameController,
+              autofocus: true,
+              textCapitalization: TextCapitalization.words,
+              decoration: InputDecoration(
+                labelText: 'Technician Name',
+                hintText: 'e.g., Ramesh Tech',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8.r),
+                ),
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 12.w,
+                  vertical: 12.h,
+                ),
+              ),
+              textInputAction: TextInputAction.next,
+              onFieldSubmitted: (_) {
+                FocusScope.of(context).nextFocus();
+              },
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Please enter technician name';
+                }
+                return null;
+              },
+            ),
+            SizedBox(height: 12.h),
+            TextFormField(
+              controller: widget.phoneController,
+              keyboardType: TextInputType.phone,
+              decoration: InputDecoration(
+                labelText: 'Phone Number',
+                hintText: 'e.g., 98765123456',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(8.r),
+                ),
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 12.w,
+                  vertical: 12.h,
+                ),
+              ),
+              textInputAction: TextInputAction.done,
+              onFieldSubmitted: (_) => _handleSave(),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Please enter phone number';
+                }
+                if (value.trim().length < 10) {
+                  return 'Phone number must be at least 10 digits';
+                }
+                return null;
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => context.pop(),
+          child: Text(
+            'Cancel',
+            style: TextStyle(
+              fontSize: 14.sp,
+              color: AppColors.textSecondary,
+            ),
+          ),
+        ),
+        ElevatedButton(
+          onPressed: _handleSave,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.secondary,
+            foregroundColor: Colors.white,
+          ),
+          child: Text(
+            'Add',
+            style: TextStyle(
+              fontSize: 14.sp,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
This pull request introduces two main enhancements: it adds support for creating a new party type directly from the "Add Party" screen, and it improves the `ProductImageWidget` to allow users to preview product images in a full-screen, zoomable view. The changes involve UI updates, state management, and improved user experience for both party type selection and product image interaction.

**Party Type Selection and Creation Improvements:**

- Replaces the old dropdown with a custom `_PartyTypeDropdown` widget that allows users to select an existing party type, clear their selection, or choose "Add New..." to input a new party type inline. The new party type is then included in the create request if provided. [[1]](diffhunk://#diff-8a6452bd88407c784268d3f5ce61723c49f91ea81cc626eba20c14f146994b4eL22-R28) [[2]](diffhunk://#diff-8a6452bd88407c784268d3f5ce61723c49f91ea81cc626eba20c14f146994b4eR61-R68) [[3]](diffhunk://#diff-8a6452bd88407c784268d3f5ce61723c49f91ea81cc626eba20c14f146994b4eR97) [[4]](diffhunk://#diff-8a6452bd88407c784268d3f5ce61723c49f91ea81cc626eba20c14f146994b4eR112) [[5]](diffhunk://#diff-8a6452bd88407c784268d3f5ce61723c49f91ea81cc626eba20c14f146994b4eR244-R258) [[6]](diffhunk://#diff-8a6452bd88407c784268d3f5ce61723c49f91ea81cc626eba20c14f146994b4eL583-R632) [[7]](diffhunk://#diff-8a6452bd88407c784268d3f5ce61723c49f91ea81cc626eba20c14f146994b4eR753-R1069)

**Product Image Widget Enhancements:**

- Refactors `ProductImageWidget` from a stateless to a stateful widget and adds tap-to-preview functionality. Users can now tap on a product image (from network or asset) to open a full-screen, zoomable preview using `photo_view`. [[1]](diffhunk://#diff-2a9f69edf36e827214e1c52cb660324c1fb10897a2414b8f370f00204f3f96eaR4) [[2]](diffhunk://#diff-2a9f69edf36e827214e1c52cb660324c1fb10897a2414b8f370f00204f3f96eaL14-R17) [[3]](diffhunk://#diff-2a9f69edf36e827214e1c52cb660324c1fb10897a2414b8f370f00204f3f96eaR29-R33) [[4]](diffhunk://#diff-2a9f69edf36e827214e1c52cb660324c1fb10897a2414b8f370f00204f3f96eaR73-R118) [[5]](diffhunk://#diff-2a9f69edf36e827214e1c52cb660324c1fb10897a2414b8f370f00204f3f96eaL95-R168) [[6]](diffhunk://#diff-2a9f69edf36e827214e1c52cb660324c1fb10897a2414b8f370f00204f3f96eaL134-R184)

These changes significantly improve the user experience for both adding parties and interacting with product images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to create new party types directly when adding or editing parties via a streamlined selection interface
  * Introduced custom category and brand creation within the prospect interest selector
  * Enabled custom category, brand, and technician creation within the site interest selector
  * Added full-screen image preview by tapping on product images with zoom support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->