### PR TITLE
patch: replaced we_chat with native_image_picker

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,8 +21,6 @@
     <uses-permission android:name="android.permission.CAMERA" />
 
     <!-- Android 13+ (API 33+) media permissions for gallery access -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <application
         android:label="SalesSphere"
@@ -105,3 +103,5 @@
         </intent>
     </queries>
 </manifest>
+
+

--- a/android/app/src/main/kotlin/com/salessphere/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/salessphere/MainActivity.kt
@@ -1,23 +1,32 @@
 package com.salessphere
 
+import android.app.Activity
 import android.content.ContentValues
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import android.webkit.MimeTypeMap
 import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
 import java.io.FileOutputStream
+import java.util.UUID
 
 class MainActivity : FlutterActivity() {
-    private val CHANNEL = "com.salessphere/downloads_saver"
+    private val DOWNLOADS_CHANNEL = "com.salessphere/downloads_saver"
+    private val PHOTO_PICKER_CHANNEL = "com.salessphere/system_photo_picker"
+    private val PICK_IMAGES_REQUEST_CODE = 7001
+
+    private var pendingPhotoPickerResult: MethodChannel.Result? = null
 
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, DOWNLOADS_CHANNEL).setMethodCallHandler { call, result ->
             if (call.method == "saveToDownloads") {
                 val fileName = call.argument<String>("fileName")
                 val bytes = call.argument<ByteArray>("bytes")
@@ -36,6 +45,90 @@ class MainActivity : FlutterActivity() {
             } else {
                 result.notImplemented()
             }
+        }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, PHOTO_PICKER_CHANNEL).setMethodCallHandler { call, result ->
+            if (call.method == "pickMultipleImages") {
+                val maxItems = (call.argument<Int>("maxItems") ?: 1).coerceAtLeast(1)
+
+                if (pendingPhotoPickerResult != null) {
+                    result.error("PICKER_IN_PROGRESS", "Photo picker is already open", null)
+                    return@setMethodCallHandler
+                }
+
+                pendingPhotoPickerResult = result
+                launchSystemPhotoPicker(maxItems)
+            } else {
+                result.notImplemented()
+            }
+        }
+    }
+
+    private fun launchSystemPhotoPicker(maxItems: Int) {
+        val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Intent(MediaStore.ACTION_PICK_IMAGES).apply {
+                type = "image/*"
+                putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, maxItems)
+            }
+        } else {
+            Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = "image/*"
+                putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+            }
+        }
+
+        startActivityForResult(intent, PICK_IMAGES_REQUEST_CODE)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode != PICK_IMAGES_REQUEST_CODE) return
+
+        val result = pendingPhotoPickerResult ?: return
+        pendingPhotoPickerResult = null
+
+        if (resultCode != Activity.RESULT_OK) {
+            result.success(emptyList<String>())
+            return
+        }
+
+        val selectedPaths = mutableListOf<String>()
+
+        val clipData = data?.clipData
+        if (clipData != null) {
+            for (index in 0 until clipData.itemCount) {
+                val uri = clipData.getItemAt(index).uri
+                copyImageToCache(uri)?.let { selectedPaths.add(it) }
+            }
+        } else {
+            val uri = data?.data
+            if (uri != null) {
+                copyImageToCache(uri)?.let { selectedPaths.add(it) }
+            }
+        }
+
+        result.success(selectedPaths)
+    }
+
+    private fun copyImageToCache(uri: Uri): String? {
+        return try {
+            val mimeType = contentResolver.getType(uri) ?: return null
+            if (!mimeType.startsWith("image/")) return null
+            val extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) ?: "jpg"
+            val file = File(cacheDir, "photo_picker_${UUID.randomUUID()}.$extension")
+
+            contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(file).use { output ->
+                    input.copyTo(output)
+                }
+            } ?: return null
+
+            file.absolutePath
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
         }
     }
 
@@ -116,3 +209,4 @@ class MainActivity : FlutterActivity() {
         }
     }
 }
+

--- a/lib/core/services/system_photo_picker_service.dart
+++ b/lib/core/services/system_photo_picker_service.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/services.dart';
+import 'package:image_picker/image_picker.dart';
+
+class SystemPhotoPickerService {
+  static const MethodChannel _channel = MethodChannel(
+    'com.salessphere/system_photo_picker',
+  );
+
+  static final ImagePicker _picker = ImagePicker();
+
+  static Future<List<XFile>> pickMultipleImages({required int maxItems}) async {
+    try {
+      final List<dynamic>? paths = await _channel.invokeMethod<List<dynamic>>(
+        'pickMultipleImages',
+        <String, dynamic>{'maxItems': maxItems},
+      );
+
+      if (paths == null || paths.isEmpty) return <XFile>[];
+
+      return paths
+          .whereType<String>()
+          .where((path) => path.isNotEmpty)
+          .map((path) => XFile(path))
+          .toList();
+    } on MissingPluginException {
+      // Native channel not registered yet (e.g., hot reload after Kotlin changes).
+      return _picker.pickMultiImage(limit: maxItems);
+    }
+  }
+}

--- a/lib/features/sites/views/sites_images_screen.dart
+++ b/lib/features/sites/views/sites_images_screen.dart
@@ -10,12 +10,12 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:sales_sphere/core/constants/app_colors.dart';
 import 'package:sales_sphere/core/network_layer/api_endpoints.dart';
 import 'package:sales_sphere/core/network_layer/dio_client.dart';
+import 'package:sales_sphere/core/services/system_photo_picker_service.dart';
 import 'package:sales_sphere/core/utils/logger.dart';
 import 'package:sales_sphere/features/sites/models/sites.model.dart';
 import 'package:sales_sphere/features/sites/views/sites_images_viewer_screen.dart';
 import 'package:sales_sphere/features/sites/vm/sites_images.vm.dart';
 import 'package:skeletonizer/skeletonizer.dart';
-import 'package:wechat_assets_picker/wechat_assets_picker.dart';
 
 class SitesImagesScreen extends ConsumerStatefulWidget {
   final String siteId;
@@ -36,54 +36,6 @@ class _SitesImagesScreenState extends ConsumerState<SitesImagesScreen> {
   bool _isUploading = false;
   String? _uploadProgress;
 
-  /// Request gallery/photos permission for Android 13+
-  Future<bool> _requestGalleryPermission() async {
-    if (Platform.isAndroid) {
-      // Android 13+ (API 33+) uses photos permission
-      final androidInfo = await _getAndroidVersion();
-      if (androidInfo >= 33) {
-        final status = await Permission.photos.status;
-        if (status.isGranted) {
-          return true;
-        }
-        final result = await Permission.photos.request();
-        if (result.isGranted) {
-          return true;
-        }
-        // If permanently denied, show settings dialog
-        if (result.isPermanentlyDenied) {
-          _showPermissionSettingsDialog('Photos');
-          return false;
-        }
-        return false;
-      } else {
-        // Android < 13 uses storage permission
-        final status = await Permission.storage.status;
-        if (status.isGranted) {
-          return true;
-        }
-        final result = await Permission.storage.request();
-        if (result.isGranted) {
-          return true;
-        }
-        if (result.isPermanentlyDenied) {
-          _showPermissionSettingsDialog('Storage');
-          return false;
-        }
-        return false;
-      }
-    } else if (Platform.isIOS) {
-      // iOS uses photos permission
-      final status = await Permission.photos.status;
-      if (status.isGranted) {
-        return true;
-      }
-      final result = await Permission.photos.request();
-      return result.isGranted;
-    }
-    return true; // Other platforms might not need explicit permission
-  }
-
   /// Request camera permission
   Future<bool> _requestCameraPermission() async {
     final status = await Permission.camera.status;
@@ -99,21 +51,6 @@ class _SitesImagesScreenState extends ConsumerState<SitesImagesScreen> {
       return false;
     }
     return false;
-  }
-
-  /// Get Android SDK version (approximate)
-  Future<int> _getAndroidVersion() async {
-    if (Platform.isAndroid) {
-      // Try to get Android version from device info
-      // Default to 33 (Android 13) if we can't determine
-      try {
-        // This is a simplified check - in production you'd use device_info_plus
-        return 33;
-      } catch (e) {
-        return 33;
-      }
-    }
-    return 0;
   }
 
   /// Show dialog to open app settings
@@ -171,38 +108,6 @@ class _SitesImagesScreenState extends ConsumerState<SitesImagesScreen> {
   /// Pick and upload multiple images (up to 9)
   Future<void> _pickMultipleImages() async {
     try {
-      // Request gallery permission first
-      final hasPermission = await _requestGalleryPermission();
-      if (!hasPermission) {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Row(
-                children: [
-                  Icon(
-                    Icons.warning_amber_rounded,
-                    color: Colors.white,
-                    size: 20.sp,
-                  ),
-                  SizedBox(width: 12.w),
-                  Expanded(
-                    child: const Text(
-                      'Gallery permission is required to select photos',
-                    ),
-                  ),
-                ],
-              ),
-              backgroundColor: AppColors.error,
-              behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12.r),
-              ),
-              margin: EdgeInsets.all(16.w),
-            ),
-          );
-        }
-        return;
-      }
 
       // Get current images to check available slots
       final currentImages = await ref.read(
@@ -239,30 +144,45 @@ class _SitesImagesScreenState extends ConsumerState<SitesImagesScreen> {
 
       // Check if widget is still mounted before proceeding
       if (!mounted) return;
+      // Pick multiple images using Android photo picker-compatible API
+      final List<XFile> pickedFiles = Platform.isAndroid
+          ? await SystemPhotoPickerService.pickMultipleImages(
+              maxItems: availableSlots,
+            )
+          : await _imagePicker.pickMultiImage(
+              limit: availableSlots,
+              maxWidth: 1920,
+              maxHeight: 1920,
+              imageQuality: 85,
+            );
 
-      // Pick multiple images using wechat_assets_picker with visual limit
-      // Shows "X/availableSlots" counter in the picker UI
-      final List<AssetEntity>? pickedAssets = await AssetPicker.pickAssets(
-        context,
-        pickerConfig: AssetPickerConfig(
-          maxAssets: availableSlots,
-          requestType: RequestType.image,
-          textDelegate: const EnglishAssetPickerTextDelegate(),
-          specialPickerType: SpecialPickerType.noPreview,
-          selectedAssets: [],
-        ),
-      );
+      if (pickedFiles.isEmpty) return;
 
-      if (pickedAssets == null || pickedAssets.isEmpty) return;
+      // Defensive cap: some picker implementations may return more than limit.
+      final List<XFile> cappedFiles = pickedFiles.length > availableSlots
+          ? pickedFiles.take(availableSlots).toList()
+          : pickedFiles;
 
-      // Convert AssetEntity to File for upload
-      final List<File> imageFiles = <File>[];
-      for (final asset in pickedAssets) {
-        final file = await asset.file;
-        if (file != null) {
-          imageFiles.add(file);
-        }
+      if (pickedFiles.length > availableSlots && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'You selected ${pickedFiles.length} photos. Only $availableSlots will be uploaded.',
+            ),
+            backgroundColor: Colors.orange,
+            behavior: SnackBarBehavior.floating,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12.r),
+            ),
+            margin: EdgeInsets.all(16.w),
+          ),
+        );
       }
+
+      // Convert selected XFiles to File for upload
+      final List<File> imageFiles = cappedFiles
+          .map((xFile) => File(xFile.path))
+          .toList();
 
       if (imageFiles.isEmpty) {
         if (mounted) {
@@ -1157,3 +1077,7 @@ class _SitesImagesScreenState extends ConsumerState<SitesImagesScreen> {
     );
   }
 }
+
+
+
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -377,22 +377,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
-  extended_image:
-    dependency: transitive
-    description:
-      name: extended_image
-      sha256: f6cbb1d798f51262ed1a3d93b4f1f2aa0d76128df39af18ecb77fa740f88b2e0
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.1"
-  extended_image_library:
-    dependency: transitive
-    description:
-      name: extended_image_library
-      sha256: "1f9a24d3a00c2633891c6a7b5cab2807999eb2d5b597e5133b63f49d113811fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -872,14 +856,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
-  http_client_helper:
-    dependency: transitive
-    description:
-      name: http_client_helper
-      sha256: "8a9127650734da86b5c73760de2b404494c968a3fd55602045ffec789dac3cb1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -1104,14 +1080,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.5.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   nm:
     dependency: transitive
     description:
@@ -1360,22 +1328,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  photo_manager:
-    dependency: transitive
-    description:
-      name: photo_manager
-      sha256: "807688e3221e90fb02a4466746edd9cb9a0de025f8754c819f96604c00f6f1f5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.8.3"
-  photo_manager_image_provider:
-    dependency: transitive
-    description:
-      name: photo_manager_image_provider
-      sha256: b6015b67b32f345f57cf32c126f871bced2501236c405aafaefa885f7c821e4f
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   photo_view:
     dependency: "direct main"
     description:
@@ -1424,14 +1376,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  provider:
-    dependency: transitive
-    description:
-      name: provider
-      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:
@@ -1973,54 +1917,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  video_player:
-    dependency: transitive
-    description:
-      name: video_player
-      sha256: "096bc28ce10d131be80dfb00c223024eb0fba301315a406728ab43dd99c45bdf"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.10.1"
-  video_player_android:
-    dependency: transitive
-    description:
-      name: video_player_android
-      sha256: ee4fd520b0cafa02e4a867a0f882092e727cdaa1a2d24762171e787f8a502b0a
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.9.1"
-  video_player_avfoundation:
-    dependency: transitive
-    description:
-      name: video_player_avfoundation
-      sha256: "2a7aaf2f28212c285e0fb29b50728bbea513d743dd48d3024098015f169fb937"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.8.10"
-  video_player_platform_interface:
-    dependency: transitive
-    description:
-      name: video_player_platform_interface
-      sha256: "57c5d73173f76d801129d0531c2774052c5a7c11ccb962f1830630decd9f24ec"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.6.0"
-  video_player_web:
-    dependency: transitive
-    description:
-      name: video_player_web
-      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.0"
-  visibility_detector:
-    dependency: transitive
-    description:
-      name: visibility_detector
-      sha256: dd5cc11e13494f432d15939c3aa8ae76844c42b723398643ce9addb88a5ed420
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.0+2"
   vm_service:
     dependency: transitive
     description:
@@ -2069,22 +1965,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  wechat_assets_picker:
-    dependency: "direct main"
-    description:
-      name: wechat_assets_picker
-      sha256: c307e50394c1e6dfcd5c4701e84efb549fce71444fedcf2e671c50d809b3e2a1
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.8.0"
-  wechat_picker_library:
-    dependency: transitive
-    description:
-      name: wechat_picker_library
-      sha256: "5cb61b9aa935b60da5b043f8446fbb9c5077419f20ccc4856bf444aec4f44bc1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.7"
   win32:
     dependency: transitive
     description:
@@ -2118,5 +1998,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.9.2 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+4
+version: 1.0.0+6
 
 environment:
   sdk: ^3.9.2
@@ -55,7 +55,6 @@ dependencies:
   geolocator: ^14.0.2
   uuid: ^4.5.1
   image_picker: ^1.2.0
-  wechat_assets_picker: ^9.5.0
   table_calendar: ^3.1.2
   photo_view: ^0.15.0
   path_provider: ^2.1.5


### PR DESCRIPTION
This pull request introduces a new Android system photo picker integration for selecting multiple images, replacing the previous custom permission handling and third-party picker logic. The changes streamline image selection for both prospects and sites, improve compatibility with Android 13+, and simplify permission management. The most important changes are grouped below:

**Android system photo picker integration:**

* Added a new `SystemPhotoPickerService` in Dart, which invokes a native Android photo picker via a platform channel and falls back to Flutter's picker if unavailable. (`lib/core/services/system_photo_picker_service.dart`)
* Implemented native Kotlin code in `MainActivity.kt` to handle the photo picker channel, launch the system picker, and return selected image paths to Flutter. (`android/app/src/main/kotlin/com/salessphere/MainActivity.kt`) [[1]](diffhunk://#diff-9d81c8c9ac3400190dc06dd483253df0681b1b45cc30623098e3accd44c6b6d9R3-R29) [[2]](diffhunk://#diff-9d81c8c9ac3400190dc06dd483253df0681b1b45cc30623098e3accd44c6b6d9R49-R132) [[3]](diffhunk://#diff-9d81c8c9ac3400190dc06dd483253df0681b1b45cc30623098e3accd44c6b6d9R212)

**Removal of custom permission handling and third-party picker:**

* Removed explicit gallery permission requests and Android SDK version checks from the image upload screens for prospects and sites. (`lib/features/prospects/views/prospect_images_screen.dart`, `lib/features/sites/views/sites_images_screen.dart`) [[1]](diffhunk://#diff-60102f56d8d1564e301e070fc8b645f4759a797eac5e9303ea8c2ebb71119218L40-L87) [[2]](diffhunk://#diff-60102f56d8d1564e301e070fc8b645f4759a797eac5e9303ea8c2ebb71119218L105-L119) [[3]](diffhunk://#diff-2b77615ade6aff390d2d572ee4d0eb62c1cfb0a99da2d339562b22aab995a0edL39-L86) [[4]](diffhunk://#diff-2b77615ade6aff390d2d572ee4d0eb62c1cfb0a99da2d339562b22aab995a0edL104-L118)
* Replaced the `wechat_assets_picker` picker logic with the new system picker service, including the image selection and upload flow. (`lib/features/prospects/views/prospect_images_screen.dart`, `lib/features/sites/views/sites_images_screen.dart`) [[1]](diffhunk://#diff-60102f56d8d1564e301e070fc8b645f4759a797eac5e9303ea8c2ebb71119218L243-R187) [[2]](diffhunk://#diff-2b77615ade6aff390d2d572ee4d0eb62c1cfb0a99da2d339562b22aab995a0edL174-L205)

**Manifest and import updates:**

* Removed Android 13+ media permissions from the manifest, since the system picker no longer requires them. (`android/app/src/main/AndroidManifest.xml`)
* Updated imports in the Dart image screens to remove the third-party picker and add the new service. (`lib/features/prospects/views/prospect_images_screen.dart`, `lib/features/sites/views/sites_images_screen.dart`) [[1]](diffhunk://#diff-60102f56d8d1564e301e070fc8b645f4759a797eac5e9303ea8c2ebb71119218R13-L18) [[2]](diffhunk://#diff-2b77615ade6aff390d2d572ee4d0eb62c1cfb0a99da2d339562b22aab995a0edR13-L18)

These changes make image selection more robust and user-friendly, especially on newer Android versions, while reducing complexity and dependency overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated native system photo picker on Android for streamlined image selection.
  * Added warning notification when selecting more images than available slots.

* **Improvements**
  * Removed unnecessary media access permissions.
  * Simplified gallery access flow.

* **Chores**
  * Updated app dependencies and bumped version to 1.0.0+6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->